### PR TITLE
Fix for compiler error (Unable to initialize compiler: lstat /go: no such file or directory)

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -41,6 +41,9 @@ import (
 	"github.com/ory/herodot"
 	"github.com/ory/keto/engine"
 	"github.com/ory/keto/engine/ladon"
+
+	// This forces go mod vendor to look for the package rego and its subpackages
+	_ "github.com/ory/keto/engine/ladon/rego"
 	"github.com/ory/keto/storage"
 	"github.com/ory/x/cmdx"
 	"github.com/ory/x/corsx"
@@ -68,7 +71,7 @@ func RunServe(
 		var s storage.Manager
 		checks := map[string]healthx.ReadyChecker{}
 
-		dbal.Connect(viper.GetString("DATABASE_URL"), logger,
+		err = dbal.Connect(viper.GetString("DATABASE_URL"), logger,
 			func() error {
 				s = storage.NewMemoryManager()
 				checks["storage"] = healthx.NoopReadyChecker

--- a/engine/ladon/rego/condition/doc.go
+++ b/engine/ladon/rego/condition/doc.go
@@ -1,0 +1,2 @@
+// Package condition is placeholder package to force download this package when we run `go mod vendor`
+package condition

--- a/engine/ladon/rego/core/doc.go
+++ b/engine/ladon/rego/core/doc.go
@@ -1,0 +1,2 @@
+// Package core is placeholder package to force download this package when we run `go mod vendor`
+package core

--- a/engine/ladon/rego/doc.go
+++ b/engine/ladon/rego/doc.go
@@ -1,0 +1,9 @@
+// Package rego is a placeholder package to force download this package and its subpackages when we run `go mod vendor`
+package rego
+
+import (
+	_ "github.com/ory/keto/engine/ladon/rego/condition"
+	_ "github.com/ory/keto/engine/ladon/rego/core"
+	_ "github.com/ory/keto/engine/ladon/rego/exact"
+	_ "github.com/ory/keto/engine/ladon/rego/regex"
+)

--- a/engine/ladon/rego/exact/doc.go
+++ b/engine/ladon/rego/exact/doc.go
@@ -1,0 +1,2 @@
+// Package exact is placeholder package to force download this package when we run `go mod vendor`
+package exact

--- a/engine/ladon/rego/regex/doc.go
+++ b/engine/ladon/rego/regex/doc.go
@@ -1,0 +1,2 @@
+// Package regex is placeholder package to force download this package when we run `go mod vendor`
+package regex


### PR DESCRIPTION
## Related issue

#73 @aeneasr 

## Proposed changes

Added placeholder .go files inside rego and its subfolders to force download rego folder when we run `go mod vendor`

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s).
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
- [x] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

