### PR TITLE
cmd: Fix disable-telemetry check

### DIFF
--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -99,7 +99,7 @@ func RunServe(
 		n := negroni.New()
 		n.Use(negronilogrus.NewMiddlewareFromLogger(logger, "keto"))
 
-		if flagx.MustGetBool(cmd, "disable-telemetry") {
+		if !flagx.MustGetBool(cmd, "disable-telemetry") {
 			logger.Println("Transmission of telemetry data is enabled, to learn more go to: https://www.ory.sh/docs/ecosystem/sqa")
 
 			m := metricsx.NewMetricsManager(


### PR DESCRIPTION
## Proposed changes

Fix the reversed disable-telemetry check

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)

## Further comments

Hydra already has similar fix https://github.com/ory/hydra/pull/1258