### PR TITLE
Fix upsert with pre-existing key will causes duplicate records

### DIFF
--- a/storage/manager_memory.go
+++ b/storage/manager_memory.go
@@ -50,9 +50,21 @@ func (m *MemoryManager) Upsert(_ context.Context, collection, key string, value 
 
 	// no need to evaluate, just create collection if necessary.
 	m.collection(collection)
+
 	m.Lock()
-	m.items[collection] = append(m.items[collection], memoryItem{Key: key, Data: b.Bytes()})
-	m.Unlock()
+	defer m.Unlock()
+
+	var found bool
+	for k, i := range m.items[collection] {
+		if i.Key == key {
+			m.items[collection][k].Data = b.Bytes()
+			found = true
+			break
+		}
+	}
+	if !found {
+		m.items[collection] = append(m.items[collection], memoryItem{Key: key, Data: b.Bytes()})
+	}
 
 	return nil
 }

--- a/storage/manager_test.go
+++ b/storage/manager_test.go
@@ -89,6 +89,21 @@ func TestMemoryManager(t *testing.T) {
 				assert.EqualValues(t, 1234, vs)
 			})
 
+			t.Run("case=upsert", func(t *testing.T) {
+				var v string
+				require.NoError(t, m.Upsert(ctx, "test-upsert", "foo", "bar"))
+				require.NoError(t, m.Get(ctx, "test-upsert", "foo", &v))
+				assert.Equal(t, "bar", v)
+
+				require.NoError(t, m.Upsert(ctx, "test-upsert", "foo", "baz"))
+				require.NoError(t, m.Get(ctx, "test-upsert", "foo", &v))
+				assert.Equal(t, "baz", v)
+
+				var vs []string
+				require.NoError(t, m.List(ctx, "test-upsert", &vs, 10, 0))
+				assert.Equal(t, 1, len(vs))
+			})
+
 			t.Run("case=list", func(t *testing.T) {
 				for i := 0; i < 10; i++ {
 					require.NoError(t, m.Upsert(ctx, "test-list", fmt.Sprintf("list-%d", i), i))


### PR DESCRIPTION
## Related issue

#80

## Proposed changes

Check if key exists before insert or update.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
