### PR TITLE
fix invalid pseudo version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,4 +68,5 @@ require (
 )
 
 // Fix for https://github.com/golang/lint/issues/436
-replace github.com/golang/lint => github.com/golang/lint v0.0.0-20190227174305-8f45f776aaf1
+replace github.com/golang/lint => github.com/golang/lint v0.0.0-20181217174547-8f45f776aaf1
+

--- a/go.sum
+++ b/go.sum
@@ -347,7 +347,7 @@ github.com/golang/gddo v0.0.0-20190312205958-5a2505f3dbf0 h1:CfaPdCDbZu8jSwjq0fl
 github.com/golang/gddo v0.0.0-20190312205958-5a2505f3dbf0/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/lint v0.0.0-20190227174305-8f45f776aaf1/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
+github.com/golang/lint v0.0.0-20181217174547-8f45f776aaf1/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
## Related issue

When on go 1.13.x:

```console
$ go clean -modcache
$ go mod download
go: github.com/ory/x@v0.0.42 requires
	cloud.google.com/go@v0.36.0 requires
	github.com/googleapis/gax-go/v2@v2.0.3 requires
	google.golang.org/grpc@v1.16.0 requires
	github.com/golang/lint@v0.0.0-20190227174305-8f45f776aaf1: invalid pseudo-version: does not match version-control timestamp (2018-12-17T17:45:47Z)
```

See the Go release notes about the "[Version validation](https://golang.org/doc/go1.13#tools)":

> The date string must match the UTC timestamp of the revision.

## Proposed changes

Change to the correct pseudo version.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
- [ ] I have documented my changes in the [developer guide](https://github.com/ory/docs) (if appropriate)
