### PR TITLE
docs: add missing colon in docker run command

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -12,7 +12,7 @@ We recommend using Docker to run ORY Keto:
 
 ```shell
 $ docker pull oryd/keto:v0.4.4-alpha.1
-$ docker run --rm -it oryd/ketov0.4.4-alpha.1 help
+$ docker run --rm -it oryd/keto:v0.4.4-alpha.1 help
 ```
 
 ## macOS

--- a/docs/versioned_docs/version-v0.5/install.md
+++ b/docs/versioned_docs/version-v0.5/install.md
@@ -12,7 +12,7 @@ We recommend using Docker to run ORY Keto:
 
 ```shell
 $ docker pull oryd/keto:v0.4.4-alpha.1
-$ docker run --rm -it oryd/ketov0.4.4-alpha.1 help
+$ docker run --rm -it oryd/keto:v0.4.4-alpha.1 help
 ```
 
 ## macOS


### PR DESCRIPTION
## Related issue
The docker run command is missing a colon.
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
