### PR TITLE
docs/docs/install.md: fix typo in docker image

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -12,7 +12,7 @@ We recommend using Docker to run ORY Keto:
 
 ```shell
 $ docker pull oryd/keto:v0.4.4-alpha.1
-$ docker run --rm -it oryd/ketov0.4.4-alpha.1 help
+$ docker run --rm -it oryd/keto:v0.4.4-alpha.1 help
 ```
 
 ## macOS


### PR DESCRIPTION
Fixed missing ':' in docker image name

## Related issue

no issue exists for this typo

## Proposed changes

Fixing a typo in the install docs

## Checklist

(no tests possible for doc text)

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ x] I have added or changed [the documentation](docs/docs).


