### PR TITLE
fix: add description attribute to access control policy role

### DIFF
--- a/.schema/api.swagger.json
+++ b/.schema/api.swagger.json
@@ -1157,6 +1157,10 @@
       "description": "oryAccessControlPolicyRole represents a group of users that share the same role. A role could be an administrator, a moderator, a regular\nuser or some other sort of role.",
       "type": "object",
       "properties": {
+        "description": {
+          "description": "Description is the description of the role.",
+          "type": "string"
+        },
         "id": {
           "description": "ID is the role's unique id.",
           "type": "string"

--- a/docs/docs/reference/api.mdx
+++ b/docs/docs/reference/api.mdx
@@ -1151,11 +1151,12 @@ Control Policy (OACP) by using the Role ID as subject in the OACP.
 
 Status Code **200**
 
-| Name        | Type                                                              | Required | Restrictions | Description                                                                                                                                                                  |
-| ----------- | ----------------------------------------------------------------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _anonymous_ | [[oryAccessControlPolicyRole](#schemaoryaccesscontrolpolicyrole)] | false    | none         | [oryAccessControlPolicyRole represents a group of users that share the same role. A role could be an administrator, a moderator, a regular user or some other sort of role.] |
-| » id        | string                                                            | false    | none         | ID is the role's unique id.                                                                                                                                                  |
-| » members   | [string]                                                          | false    | none         | Members is who belongs to the role.                                                                                                                                          |
+| Name            | Type                                                              | Required | Restrictions | Description                                                                                                                                                                  |
+| --------------- | ----------------------------------------------------------------- | -------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _anonymous_     | [[oryAccessControlPolicyRole](#schemaoryaccesscontrolpolicyrole)] | false    | none         | [oryAccessControlPolicyRole represents a group of users that share the same role. A role could be an administrator, a moderator, a regular user or some other sort of role.] |
+| » id            | string                                                            | false    | none         | ID is the role's unique id.                                                                                                                                                  |
+| » description   | string                                                            | false    | none         | Description is the description of the role                                                                                                                                   |
+| » members       | [string]                                                          | false    | none         | Members is who belongs to the role.                                                                                                                                          |
 
 Status Code **500**
 
@@ -1338,6 +1339,7 @@ Control Policy (OACP) by using the Role ID as subject in the OACP.
 ```json
 {
   "id": "string",
+  "description": "string",
   "members": ["string"]
 }
 ```
@@ -1384,6 +1386,7 @@ Status Code **500**
 ```json
 {
   "id": "string",
+  "description": "string",
   "members": ["string"]
 }
 ```
@@ -1602,6 +1605,7 @@ Status Code **500**
 ```json
 {
   "id": "string",
+  "description": "string",
   "members": ["string"]
 }
 ```
@@ -2010,6 +2014,7 @@ Status Code **500**
 ```json
 {
   "id": "string",
+  "description": "string",
   "members": ["string"]
 }
 ```
@@ -3067,6 +3072,7 @@ _Input for checking if a request is allowed or not._
 ```json
 {
   "id": "string",
+  "description": "string",
   "members": ["string"]
 }
 ```
@@ -3077,10 +3083,11 @@ other sort of role._
 
 #### Properties
 
-| Name    | Type     | Required | Restrictions | Description                         |
-| ------- | -------- | -------- | ------------ | ----------------------------------- |
-| id      | string   | false    | none         | ID is the role's unique id.         |
-| members | [string] | false    | none         | Members is who belongs to the role. |
+| Name        | Type     | Required | Restrictions | Description                                 |
+| ----------- | -------- | -------- | ------------ | ------------------------------------------- |
+| id          | string   | false    | none         | ID is the role's unique id.                 |
+| description | string   | false    | none         | Description is the description of the role. |
+| members     | [string] | false    | none         | Members is who belongs to the role.         |
 
 <a id="tocSversion">version</a>
 

--- a/engine/ladon/doc.go
+++ b/engine/ladon/doc.go
@@ -222,6 +222,9 @@ type oryAccessControlPolicyRole struct {
 	// ID is the role's unique id.
 	ID string `json:"id"`
 
+	// Description is the description of the role.
+	Description string `json:"description"`
+
 	// Members is who belongs to the role.
 	Members []string `json:"members"`
 }

--- a/engine/ladon/handler_helper_test.go
+++ b/engine/ladon/handler_helper_test.go
@@ -9,24 +9,30 @@ import (
 var (
 	roles = map[string]kstorage.Roles{
 		"regex": {{
-			ID:      "group1",
-			Members: []string{"ken"},
+			ID:          "group1",
+			Description: "group1 description",
+			Members:     []string{"ken"},
 		}, {
-			ID:      "group2",
-			Members: []string{"ken"},
+			ID:          "group2",
+			Description: "group12 description",
+			Members:     []string{"ken"},
 		}, {
-			ID:      "group3",
-			Members: []string{"ben"},
+			ID:          "group3",
+			Description: "group3 description",
+			Members:     []string{"ben"},
 		}},
 		"exact": {{
-			ID:      "group1",
-			Members: []string{"ken"},
+			ID:          "group1",
+			Description: "group1 description",
+			Members:     []string{"ken"},
 		}, {
-			ID:      "group2",
-			Members: []string{"ken"},
+			ID:          "group2",
+			Description: "group2 description",
+			Members:     []string{"ken"},
 		}, {
-			ID:      "group3",
-			Members: []string{"ben"},
+			ID:          "group3",
+			Description: "group3 description",
+			Members:     []string{"ben"},
 		}},
 	}
 	requests = map[string][]struct {

--- a/engine/ladon/handler_test.go
+++ b/engine/ladon/handler_test.go
@@ -152,8 +152,8 @@ func toSwaggerRole(r kstorage.Role) *models.OryAccessControlPolicyRole {
 
 func fromSwaggerRole(r models.OryAccessControlPolicyRole) kstorage.Role {
 	return kstorage.Role{
-		Members: r.Members,
-		ID:      r.ID,
+		Members:     r.Members,
+		ID:          r.ID,
 		Description: r.Description,
 	}
 }

--- a/engine/ladon/handler_test.go
+++ b/engine/ladon/handler_test.go
@@ -144,8 +144,9 @@ func fromSwaggerPolicy(p models.OryAccessControlPolicy) kstorage.Policy {
 
 func toSwaggerRole(r kstorage.Role) *models.OryAccessControlPolicyRole {
 	return &models.OryAccessControlPolicyRole{
-		Members: r.Members,
-		ID:      r.ID,
+		Members:     r.Members,
+		ID:          r.ID,
+		Description: r.Description,
 	}
 }
 
@@ -153,6 +154,7 @@ func fromSwaggerRole(r models.OryAccessControlPolicyRole) kstorage.Role {
 	return kstorage.Role{
 		Members: r.Members,
 		ID:      r.ID,
+		Description: r.Description,
 	}
 }
 

--- a/internal/httpclient/models/ory_access_control_policy_role.go
+++ b/internal/httpclient/models/ory_access_control_policy_role.go
@@ -16,6 +16,9 @@ import (
 // swagger:model oryAccessControlPolicyRole
 type OryAccessControlPolicyRole struct {
 
+	// Description is the description of the role.
+	Description string `json:"description,omitempty"`
+
 	// ID is the role's unique id.
 	ID string `json:"id,omitempty"`
 

--- a/storage/role.go
+++ b/storage/role.go
@@ -13,6 +13,9 @@ type Role struct {
 	// ID is the role's unique id.
 	ID string `json:"id"`
 
+	// Description is the description of the role.
+	Description string `json:"description"`
+
 	// Members is who belongs to the role.
 	Members []string `json:"members"`
 }

--- a/tests/stubs/roles.json
+++ b/tests/stubs/roles.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "role-1",
+    "description": "role-1 test",
     "members": [
       "peter-1",
       "maria-1"
@@ -8,6 +9,7 @@
   },
   {
     "id": "role-2",
+    "description": "role-2 test",
     "members": [
       "peter-2",
       "maria-2"


### PR DESCRIPTION
## Related issue

This PR fixes issue #213. 

## Proposed changes

As discussed with @aeneasr, the fix just adds the `description `attribute to the `Role `struct. Existing tests have been updated to include the new attribute, as well as the API documentation.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

Running the tests with` $ go test ./... ` (as described in the contributing guidelines) had some issues, which I don't know how to resolve. However, the issues seems to have no relation to my changes. These are the output of relevance from the above command:

```
2020/06/16 22:41:43 Could not connect to database: Could not start resource: : Post "http://localhost:2375/images/create?fromImage=postgres&tag=9.6": dial tcp [::1]:2375: connectex: No connection could be made because the target machine a
ctively refused it.
2020/06/16 22:41:43 Could not connect to database: Could not start resource: : Post "http://localhost:2375/images/create?fromImage=mysql&tag=5.7": dial tcp [::1]:2375: connectex: No connection could be made because the target machine acti
vely refused it.
```

The tests were run in a Cygwin64 terminal on Windows, and the host had Docker installed.

