### PR TITLE
chore: update repository template to e3cc51a3

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+## Related issue
+
+<!--
+Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
+with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).
+
+If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
+chance substantial changes will be requested or that the changes will be rejected.
+
+You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
+join the [ORY Chat](https://www.ory.sh/chat).
+-->
+
+## Proposed changes
+
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
+-->
+
+## Checklist
+
+<!--
+Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
+them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
+-->
+
+- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
+- [ ] I have read the [security policy](../security/policy).
+- [ ] I confirm that this pull request does not address a security
+      vulnerability. If this pull request addresses a security. vulnerability, I
+      confirm that I got green light (please contact
+      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
+      the changes.
+- [ ] I have added tests that prove my fix is effective or that my feature
+      works.
+- [ ] I have added or changed [the documentation](docs/docs).
+
+## Further comments
+
+<!--
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
+you did and what alternatives you considered, etc...
+-->

--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -1,0 +1,24 @@
+name: Closed Reference Notifier
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      issueLimit:
+        description: Max. number of issues to create
+        required: true
+        default: '5'
+
+jobs:
+  find_closed_references:
+    runs-on: ubuntu-latest
+    name: Find closed references
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ory/closed-reference-notifier@v1.1.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ignore: '.git,**/node_modules,docs,CHANGELOG.md,.bin'
+          issueLabels: upstream
+          issueLimit: ${{ github.event.inputs.issueLimit || '5' }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,3 @@
-
 name: Synchronize Issue Labels
 
 on:

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -3,7 +3,7 @@ name: Generate and Publish Milestone Document
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   milestone:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,24 +1,24 @@
-name: "Close stale issues"
+name: "Close Stale Issues"
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: |
-          Thank you for opening this issue. It appears that the request for more information (e.g. providing the software version, providing logs, ...) has not yet been completed. Therefore this issue will be automatically
-          closed in 7 days, assuming that the issue has been resolved.
-        stale-pr-message: |
-          Thank you for opening this pull request. It appears that a request for e.g. information has not yet been completed. Therefore this issue will be automatically
-          closed in 7 days, assuming that the proposed change is no longer required or has otherwise been resolved.
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
-        only-labels: 'needs more info'
-        days-before-stale: 7
-        days-before-close: 7
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: |
+            Thank you for opening this issue. It appears that the request for more information (e.g. providing the software version, providing logs, ...) has not yet been completed. Therefore this issue will be automatically
+            closed in 7 days, assuming that the issue has been resolved.
+          stale-pr-message: |
+            Thank you for opening this pull request. It appears that a request for e.g. information has not yet been completed. Therefore this issue will be automatically
+            closed in 7 days, assuming that the proposed change is no longer required or has otherwise been resolved.
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          only-labels: 'needs more info'
+          days-before-stale: 7
+          days-before-close: 7

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ been able to achieve this without each and everyone of you!
 The following list represents companies that have accompanied us along the way
 and that have made outstanding contributions to our ecosystem. _If you think
 that your company deserves a spot here, reach out to
-<a href="mailto:hi@ory.sh">hi@ory.sh</a> now_!
+<a href="mailto:office@ory.sh">office@ory.sh</a> now_!
 
 **Please consider giving back by becoming a sponsor of our open source work on
 <a href="https://www.patreon.com/_ory">Patreon</a> or
@@ -194,6 +194,7 @@ TheCrealm.
 
 
 
+
 ### Installation
 
 Head over to the documentation to learn about ways of [installing ORY Keto](https://www.ory.sh/docs/next/keto/install).
@@ -248,6 +249,7 @@ determine whether a subject (user, application, service, car, ...) is authorized
 to perform a certain action on a resource.
 
 <!--END ECOSYSTEM-->
+
 
 
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,3 +1,8 @@
+---
+id: contributing
+title: Contribution Guidelines
+---
+
 <!--
 
 Thank you for contributing changes to this document! Because we use a central repository


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/e3cc51a3e1b1609daaf59b29ab140b6a3d2dadbe.