### PR TITLE
chore: update docusaurus template

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -2,12 +2,13 @@ const config = require('./contrib/config.js')
 const fs = require('fs')
 const admonitions = require('remark-admonitions')
 
-const githubRepoName =
-  config.projectSlug === 'ecosystem' ? 'docs' : config.projectSlug
+const githubRepoName = config.projectSlug === 'ecosystem'
+  ? 'docs'
+  : config.projectSlug
 
 const links = [
   {
-    to: '/',
+    to: "/",
     activeBasePath: `${config.projectSlug}/docs`,
     label: `Docs`,
     position: 'left'
@@ -79,9 +80,7 @@ module.exports = {
       logo: {
         alt: config.projectName,
         src: `img/logo-${config.projectSlug}.svg`,
-        href: `https://www.ory.sh/${
-          config.projectSlug === 'ecosystem' ? '' : config.projectSlug
-        }`
+        href: `https://www.ory.sh/${config.projectSlug === 'ecosystem' ? '' : config.projectSlug}`
       },
       items: links
     },

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,10 @@
   "name": "docusaurus-template",
   "version": "0.0.0",
   "private": true,
+  "consts": {
+    "prettierTarget": "{docs/**,docs,scripts,static,contrib}/*.{md,mdx,json,js,css,html}|*.{js,md}",
+    "prettierArgs": "--no-semi --single-quote --trailing-comma none"
+  },
   "scripts": {
     "gen": "npm run widdershins && cd .. && node ./docs/scripts/fix-api.js ./docs/docs/reference/api.mdx && node ./docs/scripts/config.js docs/config.js",
     "docusaurus": "docusaurus",
@@ -10,7 +14,8 @@
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
-    "format": "prettier --write '{docs/**,docs,scripts,static,contrib}/*.{md,mdx,json,js,css,html}|*.{js,md}' --no-semi --single-quote --trailing-comma none || true"
+    "format": "prettier --write ${npm_package_consts_prettierTarget} ${npm_package_consts_prettierArgs} || true",
+    "format:check": "prettier --check ${npm_package_consts_prettierTarget} ${npm_package_consts_prettierArgs}"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.61",


### PR DESCRIPTION
Updated docusaurus template to current https://github.com/ory/docusaurus-template.