### PR TITLE
fix: Use make() to initialise array of Policy and Role instead of leaving it uninitalised

### DIFF
--- a/engine/ladon/handler.go
+++ b/engine/ladon/handler.go
@@ -290,8 +290,7 @@ func (e *Engine) Register(r *httprouter.Router) {
 }
 
 func (e *Engine) rolesList(ctx context.Context, r *http.Request, ps httprouter.Params) (*kstorage.ListRequest, error) {
-	var p kstorage.Roles
-
+	p := make([]kstorage.Role, 0)
 	f, err := flavor(ps)
 	if err != nil {
 		return nil, err
@@ -428,8 +427,8 @@ func (e *Engine) policiesCreate(ctx context.Context, r *http.Request, ps httprou
 }
 
 func (e *Engine) policiesList(ctx context.Context, r *http.Request, ps httprouter.Params) (*kstorage.ListRequest, error) {
-	var p kstorage.Policies
 
+	p := make([]kstorage.Policy, 0)
 	f, err := flavor(ps)
 	if err != nil {
 		return nil, err

--- a/engine/ladon/handler.go
+++ b/engine/ladon/handler.go
@@ -290,7 +290,7 @@ func (e *Engine) Register(r *httprouter.Router) {
 }
 
 func (e *Engine) rolesList(ctx context.Context, r *http.Request, ps httprouter.Params) (*kstorage.ListRequest, error) {
-	p := make([]kstorage.Role, 0)
+	p := make(kstorage.Roles, 0)
 	f, err := flavor(ps)
 	if err != nil {
 		return nil, err
@@ -428,7 +428,7 @@ func (e *Engine) policiesCreate(ctx context.Context, r *http.Request, ps httprou
 
 func (e *Engine) policiesList(ctx context.Context, r *http.Request, ps httprouter.Params) (*kstorage.ListRequest, error) {
 
-	p := make([]kstorage.Policy, 0)
+	p := make(kstorage.Policies, 0)
 	f, err := flavor(ps)
 	if err != nil {
 		return nil, err

--- a/storage/filter_helper_test.go
+++ b/storage/filter_helper_test.go
@@ -52,7 +52,7 @@ var (
 				Members: []string{"mem1", "mem2"},
 			},
 		},
-		nil,
+		Roles{},
 		rolReq,
 		rolReq,
 		rolReq,
@@ -93,7 +93,7 @@ var (
 				Resources: []string{"res1", "res2"},
 			},
 		},
-		nil,
-		nil,
+		Policies{},
+		Policies{},
 	}
 )

--- a/storage/filter_helper_test.go
+++ b/storage/filter_helper_test.go
@@ -35,7 +35,7 @@ var (
 		{"action": {"create"}, "subject": {"mem3"}, "resource": {"res3"}},
 		{"action": {"delete"}},
 	}
-	rolRes = []Roles{
+	rolRes = [][]Role{
 		[]Role{
 			{
 				ID:      "role1",
@@ -59,7 +59,7 @@ var (
 		rolReq,
 		rolReq,
 	}
-	polRes = []Policies{
+	polRes = [][]Policy{
 		polReq,
 		polReq,
 		polReq,

--- a/storage/filter_helper_test.go
+++ b/storage/filter_helper_test.go
@@ -1,7 +1,7 @@
 package storage
 
 var (
-	rolReq = []Role{
+	rolReq = Roles{
 		{
 			ID:      "role1",
 			Members: []string{"mem1"},
@@ -11,7 +11,7 @@ var (
 			Members: []string{"mem1", "mem2"},
 		},
 	}
-	polReq = []Policy{
+	polReq = Policies{
 		{
 			ID:        "policy1",
 			Actions:   []string{"create"},
@@ -35,8 +35,8 @@ var (
 		{"action": {"create"}, "subject": {"mem3"}, "resource": {"res3"}},
 		{"action": {"delete"}},
 	}
-	rolRes = [][]Role{
-		[]Role{
+	rolRes = []Roles{
+		Roles{
 			{
 				ID:      "role1",
 				Members: []string{"mem1"},
@@ -46,24 +46,24 @@ var (
 				Members: []string{"mem1", "mem2"},
 			},
 		},
-		[]Role{
+		Roles{
 			{
 				ID:      "role2",
 				Members: []string{"mem1", "mem2"},
 			},
 		},
-		[]Role{},
+		nil,
 		rolReq,
 		rolReq,
 		rolReq,
 		rolReq,
 		rolReq,
 	}
-	polRes = [][]Policy{
+	polRes = []Policies{
 		polReq,
 		polReq,
 		polReq,
-		[]Policy{
+		Policies{
 			{
 				ID:        "policy1",
 				Actions:   []string{"create"},
@@ -77,7 +77,7 @@ var (
 				Resources: []string{"res1", "res2"},
 			},
 		},
-		[]Policy{
+		Policies{
 			{
 				ID:        "policy2",
 				Actions:   []string{"create"},
@@ -85,7 +85,7 @@ var (
 				Resources: []string{"res1", "res2"},
 			},
 		},
-		[]Policy{
+		Policies{
 			{
 				ID:        "policy2",
 				Actions:   []string{"create"},
@@ -93,7 +93,7 @@ var (
 				Resources: []string{"res1", "res2"},
 			},
 		},
-		[]Policy{},
-		[]Policy{},
+		nil,
+		nil,
 	}
 )

--- a/storage/filter_helper_test.go
+++ b/storage/filter_helper_test.go
@@ -1,7 +1,7 @@
 package storage
 
 var (
-	rolReq = Roles{
+	rolReq = []Role{
 		{
 			ID:      "role1",
 			Members: []string{"mem1"},
@@ -11,7 +11,7 @@ var (
 			Members: []string{"mem1", "mem2"},
 		},
 	}
-	polReq = Policies{
+	polReq = []Policy{
 		{
 			ID:        "policy1",
 			Actions:   []string{"create"},
@@ -36,7 +36,7 @@ var (
 		{"action": {"delete"}},
 	}
 	rolRes = []Roles{
-		Roles{
+		[]Role{
 			{
 				ID:      "role1",
 				Members: []string{"mem1"},
@@ -46,7 +46,7 @@ var (
 				Members: []string{"mem1", "mem2"},
 			},
 		},
-		Roles{
+		[]Role{
 			{
 				ID:      "role2",
 				Members: []string{"mem1", "mem2"},
@@ -63,7 +63,7 @@ var (
 		polReq,
 		polReq,
 		polReq,
-		Policies{
+		[]Policy{
 			{
 				ID:        "policy1",
 				Actions:   []string{"create"},
@@ -77,7 +77,7 @@ var (
 				Resources: []string{"res1", "res2"},
 			},
 		},
-		Policies{
+		[]Policy{
 			{
 				ID:        "policy2",
 				Actions:   []string{"create"},
@@ -85,7 +85,7 @@ var (
 				Resources: []string{"res1", "res2"},
 			},
 		},
-		Policies{
+		[]Policy{
 			{
 				ID:        "policy2",
 				Actions:   []string{"create"},

--- a/storage/filter_helper_test.go
+++ b/storage/filter_helper_test.go
@@ -52,7 +52,7 @@ var (
 				Members: []string{"mem1", "mem2"},
 			},
 		},
-		nil,
+		[]Role{},
 		rolReq,
 		rolReq,
 		rolReq,
@@ -93,7 +93,7 @@ var (
 				Resources: []string{"res1", "res2"},
 			},
 		},
-		nil,
-		nil,
+		[]Policy{},
+		[]Policy{},
 	}
 )

--- a/storage/handler.go
+++ b/storage/handler.go
@@ -84,8 +84,8 @@ func (l *ListRequest) Filter(m map[string][]string) *ListRequest {
 
 func ListByQuery(l *ListRequest, m map[string][]string) {
 	switch val := l.Value.(type) {
-	case *Roles:
-		var res Roles
+	case *[]Role:
+		res := make([]Role, 0)
 		for _, role := range *val {
 			filteredRole := role.withMembers(m["member"]).withIDs(m["id"])
 			if filteredRole != nil {
@@ -93,8 +93,8 @@ func ListByQuery(l *ListRequest, m map[string][]string) {
 			}
 		}
 		l.Value = &res
-	case *Policies:
-		var res Policies
+	case *[]Policy:
+		res := make([]Policy, 0)
 		for _, policy := range *val {
 			filteredPolicy := policy.withSubjects(m["subject"]).withResources(m["resource"]).withActions(m["action"]).withIDs(m["id"])
 			if filteredPolicy != nil {

--- a/storage/handler.go
+++ b/storage/handler.go
@@ -84,8 +84,8 @@ func (l *ListRequest) Filter(m map[string][]string) *ListRequest {
 
 func ListByQuery(l *ListRequest, m map[string][]string) {
 	switch val := l.Value.(type) {
-	case *[]Role:
-		res := make([]Role, 0)
+	case *Roles:
+		res := make(Roles, 0)
 		for _, role := range *val {
 			filteredRole := role.withMembers(m["member"]).withIDs(m["id"])
 			if filteredRole != nil {
@@ -93,8 +93,8 @@ func ListByQuery(l *ListRequest, m map[string][]string) {
 			}
 		}
 		l.Value = &res
-	case *[]Policy:
-		res := make([]Policy, 0)
+	case *Policies:
+		res := make(Policies, 0)
 		for _, policy := range *val {
 			filteredPolicy := policy.withSubjects(m["subject"]).withResources(m["resource"]).withActions(m["action"]).withIDs(m["id"])
 			if filteredPolicy != nil {


### PR DESCRIPTION
Fixes #217 
This is an ongoing issue in `encoding/json`, whereby if an uninitialised array (such as policies, which is declared as `var p Policies`, or roles, which is declared as `var p Roles`) is attempted to be encoded using `json.Marshal`, it results in a `nil` value being returned instead of `[]`.

Given that json doesn't appear to be merging the currently open PR to add an option to return nil as [] or {} in when json.Marshal is used anytime soon, this patch should fix that.

I've updated the tests in filter_test.go and filter_helper_test.go to replace the expected nil values with the relevant empty Role/Policy object.

## Related issue

#217
https://github.com/golang/go/issues/27589
## Proposed changes


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

Below is the tracing process that I posted on #217 

I've been tracing this bug because it also affects us at work, and I've traced it to this
`func (h *Handler) List(factory func(context.Context, *http.Request, httprouter.Params) (*ListRequest, error)) httprouter.Handle` in `storage/handler.go` returns a `h.h.Write(w, r, l.Filter(m).Value)`, and in this case, `l.Filter(m).Value` returns `*storage.Policies`, which is declared as a type of []Policy .

`h`, in this case, which is a type of `herodot.Writer`, an interface, in this particular function, is a `herodot.JSONWriter`, and   `Write` in this case calls `WriteCode` [here](https://github.com/ory/herodot/blob/master/json.go). This tells me that there's an issue with `encoding/json`'s  `json.Marshal(e)`, where `e` refers to `l.Filter(m).Value`.


I believe this is due to https://github.com/golang/go/issues/27589, and a proposal has been made to modify `encoding/json` that is still under going review [here](https://go-review.googlesource.com/c/go/+/136761/) and awaiting a PR at https://github.com/golang/go/issues/37711.

At this point, I'm wondering if I should submit a PR to `ory/herodot`, to do the checking in `func WriteCode`. If it is a shared library, do you think that this will affect other projects that ory has?

There's a quick fix, as can be seen from https://github.com/CosmWasm/go-cosmwasm/pull/75, to quickly check the value, and if it's nil, do not even proceed with `JSON.Marshal`. This might actually be the fastest way to fix this, but I'm unsure about the potential impact, given that herodot is a shared repository.

Ultimately, the issue lies in `func ListByQuery` in `storage/handler.go`, which declares var res Roles and var res Policies without explicitly initialising them, as well as `func rolesList` and `func policiesList` in `engine/ladon/handler.go`, which does the same.