### PR TITLE
chore: update repository template to cf87b803

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -86,8 +86,7 @@ Please follow these guidelines when formatting source code:
 Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's `docs` folder.
 
-In cases where a project does not have a `docs` folder check the README for
-instructions.
+In cases where a project does not have a `docs` folder check the README for instructions.
 
 The commands listed below work exclusively for projects with a `docs` folder
 
@@ -109,8 +108,8 @@ To start a local development server with hot reloading, run:
 $ npm start
 ```
 
-This command opens up a browser window. Please note that changes to the sidebar
-are not hot-reloaded and require a restart of the command.
+This command opens up a browser window. Please note that changes to the sidebar are not hot-reloaded
+and require a restart of the command.
 
 #### Build
 
@@ -147,32 +146,27 @@ please include a note in your commit message explaining why.
 
 ## How We Organize Our Work
 
-All repositories in the [ORY organization](https://github.com/ory) have their
-issues and pull requests monitored in the
-[ORY Monitoring Board](https://github.com/orgs/ory/projects/9). This allows for
-a transparent backlog of unanswered issues and pull requests across the
-ecosystem from those who are allowed to merge pull requests to the main branch.
+All repositories in the [ORY organization](https://github.com/ory) have their issues and pull requests
+monitored in the [ORY Monitoring Board](https://github.com/orgs/ory/projects/9). This allows
+for a transparent backlog of unanswered issues and pull requests across the ecosystem from those
+who are allowed to merge pull requests to the main branch.
 
 The process is as follows:
 
-1. _Cards_ represent open issues and pull requests and are automatically
-   assigned to the **Triage** column if the author is not one of the maintainers
-   and no maintainer has answered yet.
-2. A maintainer assigns the issue or pull request to someone or adds the label
-   _help wanted_ which moves the card to **Requires Action**.
-3. If a maintainer leaves a comment or review, the card moves to **Pending
-   Reply**, implying that the original author needs to do something (e.g.
-   implement a change, explain something in more detail, ...).
-4. If a non-maintainer pushes changes to the pull request or leaves a comment,
-   the card moves back to **Requires Action**.
-5. If a card stays inactive for 60 days or more days, we assume that public
-   interest in the issue or change has waned, **archiving** the card.
-6. If the issue is closed or the pull request merged or closed, the card is
-   **archived** as well.
+1. _Cards_ represent open issues and pull requests and are automatically assigned to the **Triage** column if
+   the author is not one of the maintainers and no maintainer has answered yet.
+2. A maintainer assigns the issue or pull request to someone or adds the label _help wanted_
+   which moves the card to **Requires Action**.
+3. If a maintainer leaves a comment or review, the card moves to **Pending Reply**, implying that
+   the original author needs to do something (e.g. implement a change, explain something in more detail, ...).
+4. If a non-maintainer pushes changes to the pull request or leaves a comment, the card moves
+   back to **Requires Action**.
+5. If a card stays inactive for 60 days or more days, we assume that public interest in the issue
+   or change has waned, **archiving** the card.
+6. If the issue is closed or the pull request merged or closed, the card is **archived** as well.
 
-We try our best to answer all issues and review all pull requests and hope that
-this transparent way of keeping a backlog helps you better understand how heavy
-the workload is.
+We try our best to answer all issues and review all pull requests and hope that this transparent way
+of keeping a backlog helps you better understand how heavy the workload is.
 
 ## Communication
 


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/cf87b803caaeba66883090e7e21c6d8c07192d96.