### PR TITLE
feat: dockerfile - use CMD, disable CGO, use distroless/static image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 # To compile this image manually run:
 #
-# $ packr; GO111MODULE=on GOOS=linux GOARCH=amd64 go build; docker build -t oryd/keto:latest .; rm keto; packr clean
-FROM alpine:3.9
+# $ packr; GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build; docker build . -t oryd/keto:latest; rm keto; packr clean
 
-RUN apk add -U --no-cache ca-certificates
-
-FROM scratch
-
-COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY keto /usr/bin/keto
-
+# Use distroless/static as minimal base image that contains:
+# - ca-certificates
+# - A /etc/passwd entry for a root user
+# - A /tmp directory
+# - tzdata
+#
+# Refer to https://github.com/GoogleContainerTools/distroless for more details.
+FROM gcr.io/distroless/static:latest
 USER 1000
-
-ENTRYPOINT ["keto"]
-
-CMD ["serve"]
+COPY keto /usr/bin/keto
+CMD ["keto", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ sdk: deps
 .PHONY: docker
 docker: deps
 		packr
-		GO111MODULE=on GOOS=linux GOARCH=amd64 go build
+		GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
 		docker build -t oryd/keto:latest .
 		rm keto
 		packr clean


### PR DESCRIPTION
- replace `ENTRYPOINT` with `CMD` to allow overriding the container run command by users
- disable CGO when compiling as its not needed and fixes the common `standard_init_linux.go:211: exec user process caused "no such file or directory"` error developers may face, because of linking to C libs that are not present in slim image
- simply use `GoogleContainerTools/distroless` as base image