### PR TITLE
chore: update repository template to 8042a8da

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -38,9 +38,9 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY Keto's security and our users' trust very
-seriously. If you believe you have found a security issue in ORY Keto,
-please responsibly disclose by contacting us at security@ory.sh.
+_Please note_: We take ORY Keto's security and our users' trust very seriously.
+If you believe you have found a security issue in ORY Keto, please responsibly
+disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
 hour of the day or night, weekdays, weekends, and holidays. Please do not ever
@@ -53,8 +53,8 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY Keto's normal direction. A great way to
-do this is via the [ORY Community](https://community.ory.sh/) or join the
+won't clash or be obviated by ORY Keto's normal direction. A great way to do
+this is via the [ORY Community](https://community.ory.sh/) or join the
 [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
@@ -72,9 +72,8 @@ do this is via the [ORY Community](https://community.ory.sh/) or join the
 - I want to talk to other ORY Keto users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to ORY
-  Keto. Does ORY have
-  [a Contributors License Agreement?](https://cla-assistant.io/ory/)
+- I would like to know what I am agreeing to when I contribute to ORY Keto. Does
+  ORY have [a Contributors License Agreement?](https://cla-assistant.io/ory/)
 
 - I would like updates about new versions of ORY Keto.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
@@ -88,16 +87,16 @@ There are many other ways you can contribute without writing any code. Here are
 a few things you can do to help out:
 
 - **Give us a star.** It may not seem like much, but it really makes a
-  difference. This is something that everyone can do to help out ORY
-  Keto. Github stars help the project gain visibility and stand out.
+  difference. This is something that everyone can do to help out ORY Keto.
+  Github stars help the project gain visibility and stand out.
 
 - **Join the community.** Sometimes helping people can be as easy as listening
   to their problems and offering a different perspective. Join our Slack, have a
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY Keto
-  and some of them may lack necessary information, some are duplicates of older
+- **Helping with open issues.** We have a lot of open issues for ORY Keto and
+  some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
   existing issues that match their description of the problem.
@@ -122,9 +121,9 @@ You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY Keto,
-consider joining the mailing list. We will _only_ send you vital information on
-the projects that you are interested in.
+If you want to receive regular notifications about updates to ORY Keto, consider
+joining the mailing list. We will _only_ send you vital information on the
+projects that you are interested in.
 
 Also [follow us on twitter](https://twitter.com/orycorp).
 
@@ -132,8 +131,8 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Keto's
-roadmap and architecture.
+before getting started to ensure your work is consistent with ORY Keto's roadmap
+and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
 contributors get reviewed**. After a pull request is made other contributors
@@ -163,8 +162,8 @@ should be merged by the submitter after review.
 
 Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's
-[docs](https://github.com/ory/Keto/tree/master/docs) folder. Generate API
-and configuration reference documentation using `cd docs; npm run gen`.
+[docs](https://github.com/ory/Keto/tree/master/docs) folder. Generate API and
+configuration reference documentation using `cd docs; npm run gen`.
 
 For further instructions please head over to
 [docs/README.md](https://github.com/ory/Keto/blob/master/README.md).
@@ -249,8 +248,8 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY
-  Keto core team immediately.
+  member, please contact one of the channel ops or a member of the ORY Keto core
+  team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 

--- a/docs/docs/reference/api.mdx
+++ b/docs/docs/reference/api.mdx
@@ -3,21 +3,26 @@ title: REST API
 id: api
 ---
 
-Ory Keto is a cloud native access control server providing best-practice patterns (RBAC, ABAC, ACL, AWS IAM Policies, Kubernetes Roles, ...) via REST APIs.
+Ory Keto is a cloud native access control server providing best-practice
+patterns (RBAC, ABAC, ACL, AWS IAM Policies, Kubernetes Roles, ...) via REST
+APIs.
 
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
 :::info
 
-You are viewing REST API documentation. This documentation is auto-generated from a swagger specification which
-itself is generated from annotations in the source code of the project. It is possible that this documentation includes
-bugs and that code samples are incomplete or wrong.
+You are viewing REST API documentation. This documentation is auto-generated
+from a swagger specification which itself is generated from annotations in the
+source code of the project. It is possible that this documentation includes bugs
+and that code samples are incomplete or wrong.
 
 If you find issues in the respective documentation, please do not edit the
-Markdown files directly (as they are generated) but raise an issue on the project's GitHub presence instead. This documentation
-will improve over time with your help! If you have ideas how to improve this part of the documentation, feel free to
-share them in a [GitHub issue](https://github.com/ory/docs/issues/new) any time.
+Markdown files directly (as they are generated) but raise an issue on the
+project's GitHub presence instead. This documentation will improve over time
+with your help! If you have ideas how to improve this part of the documentation,
+feel free to share them in a
+[GitHub issue](https://github.com/ory/docs/issues/new) any time.
 
 :::
 
@@ -36,9 +41,9 @@ Accept: application/json
 
 ```
 
-Use this endpoint to check if a request is allowed or not. If the request is allowed, a 200 response with
-`{"allowed":"true"}` will be sent. If the request is denied, a 403 response with `{"allowed":"false"}` will
-be sent instead.
+Use this endpoint to check if a request is allowed or not. If the request is
+allowed, a 200 response with `{"allowed":"true"}` will be sent. If the request
+is denied, a 403 response with `{"allowed":"false"}` will be sent instead.
 
 #### Request body
 
@@ -1062,8 +1067,8 @@ Accept: application/json
 
 ```
 
-Roles group several subjects into one. Rules can be assigned to ORY Access Control Policy (OACP) by using the Role ID
-as subject in the OACP.
+Roles group several subjects into one. Rules can be assigned to ORY Access
+Control Policy (OACP) by using the Role ID as subject in the OACP.
 
 <a id="list-ory-access-control-policy-roles-parameters"></a>
 
@@ -1262,8 +1267,8 @@ Accept: application/json
 
 ```
 
-Roles group several subjects into one. Rules can be assigned to ORY Access Control Policy (OACP) by using the Role ID
-as subject in the OACP.
+Roles group several subjects into one. Rules can be assigned to ORY Access
+Control Policy (OACP) by using the Role ID as subject in the OACP.
 
 #### Request body
 
@@ -1468,8 +1473,8 @@ Accept: application/json
 
 ```
 
-Roles group several subjects into one. Rules can be assigned to ORY Access Control Policy (OACP) by using the Role ID
-as subject in the OACP.
+Roles group several subjects into one. Rules can be assigned to ORY Access
+Control Policy (OACP) by using the Role ID as subject in the OACP.
 
 <a id="get-an-ory-access-control-policy-role-parameters"></a>
 
@@ -1666,8 +1671,8 @@ Accept: application/json
 
 ```
 
-Roles group several subjects into one. Rules can be assigned to ORY Access Control Policy (OACP) by using the Role ID
-as subject in the OACP.
+Roles group several subjects into one. Rules can be assigned to ORY Access
+Control Policy (OACP) by using the Role ID as subject in the OACP.
 
 <a id="delete-an-ory-access-control-policy-role-parameters"></a>
 
@@ -1856,8 +1861,8 @@ Accept: application/json
 
 ```
 
-Roles group several subjects into one. Rules can be assigned to ORY Access Control Policy (OACP) by using the Role ID
-as subject in the OACP.
+Roles group several subjects into one. Rules can be assigned to ORY Access
+Control Policy (OACP) by using the Role ID as subject in the OACP.
 
 #### Request body
 
@@ -2059,8 +2064,8 @@ Accept: application/json
 
 ```
 
-Roles group several subjects into one. Rules can be assigned to ORY Access Control Policy (OACP) by using the Role ID
-as subject in the OACP.
+Roles group several subjects into one. Rules can be assigned to ORY Access
+Control Policy (OACP) by using the Role ID as subject in the OACP.
 
 <a id="remove-a-member-from-an-ory-access-control-policy-role-parameters"></a>
 
@@ -2253,14 +2258,15 @@ Accept: application/json
 
 ```
 
-This endpoint returns a 200 status code when the HTTP server is up running.
-This status does currently not include checks whether the database connection is working.
+This endpoint returns a 200 status code when the HTTP server is up running. This
+status does currently not include checks whether the database connection is
+working.
 
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 
-Be aware that if you are running multiple nodes of this service, the health status will never
-refer to the cluster state, only to a single instance.
+Be aware that if you are running multiple nodes of this service, the health
+status will never refer to the cluster state, only to a single instance.
 
 #### Responses
 
@@ -2434,14 +2440,14 @@ Accept: application/json
 
 ```
 
-This endpoint returns a 200 status code when the HTTP server is up running and the environment dependencies (e.g.
-the database) are responsive as well.
+This endpoint returns a 200 status code when the HTTP server is up running and
+the environment dependencies (e.g. the database) are responsive as well.
 
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 
-Be aware that if you are running multiple nodes of this service, the health status will never
-refer to the cluster state, only to a single instance.
+Be aware that if you are running multiple nodes of this service, the health
+status will never refer to the cluster state, only to a single instance.
 
 #### Responses
 
@@ -2604,13 +2610,14 @@ Accept: application/json
 
 ```
 
-This endpoint returns the service version typically notated using semantic versioning.
+This endpoint returns the service version typically notated using semantic
+versioning.
 
 If the service supports TLS Edge Termination, this endpoint does not require the
 `X-Forwarded-Proto` header to be set.
 
-Be aware that if you are running multiple nodes of this service, the health status will never
-refer to the cluster state, only to a single instance.
+Be aware that if you are running multiple nodes of this service, the health
+status will never refer to the cluster state, only to a single instance.
 
 #### Responses
 
@@ -2790,7 +2797,8 @@ p JSON.parse(result)
 }
 ```
 
-_AuthorizationResult is the result of an access control decision. It contains the decision outcome._
+_AuthorizationResult is the result of an access control decision. It contains
+the decision outcome._
 
 #### Properties
 
@@ -2910,8 +2918,9 @@ _Input for checking if a request is allowed or not._
 }
 ```
 
-_oryAccessControlPolicyRole represents a group of users that share the same role. A role could be an administrator, a moderator, a regular
-user or some other sort of role._
+_oryAccessControlPolicyRole represents a group of users that share the same
+role. A role could be an administrator, a moderator, a regular user or some
+other sort of role._
 
 #### Properties
 

--- a/docs/docs/reference/configuration.md
+++ b/docs/docs/reference/configuration.md
@@ -7,22 +7,27 @@ title: Configuration
 OPEN AN ISSUE IF YOU WOULD LIKE TO MAKE ADJUSTMENTS HERE AND MAINTAINERS WILL HELP YOU LOCATE THE RIGHT
 FILE -->
 
-If file `$HOME/.keto.yaml` exists, it will be used as a configuration file which supports all
-configuration settings listed below.
+If file `$HOME/.keto.yaml` exists, it will be used as a configuration file which
+supports all configuration settings listed below.
 
-You can load the config file from another source using the `-c path/to/config.yaml` or `--config path/to/config.yaml`
-flag: `keto --config path/to/config.yaml`.
+You can load the config file from another source using the
+`-c path/to/config.yaml` or `--config path/to/config.yaml` flag:
+`keto --config path/to/config.yaml`.
 
-Config files can be formatted as JSON, YAML and TOML. Some configuration values support reloading without server restart.
-All configuration values can be set using environment variables, as documented below.
+Config files can be formatted as JSON, YAML and TOML. Some configuration values
+support reloading without server restart. All configuration values can be set
+using environment variables, as documented below.
 
-This reference configuration documents all keys, also deprecated ones!
-It is a reference for all possible configuration values.
+This reference configuration documents all keys, also deprecated ones! It is a
+reference for all possible configuration values.
 
-If you are looking for an example configuration, it is better to try out the quickstart.
+If you are looking for an example configuration, it is better to try out the
+quickstart.
 
-To find out more about edge cases like setting string array values through environmental variables head to the
-[Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring) section.
+To find out more about edge cases like setting string array values through
+environmental variables head to the
+[Configuring ORY services](https://www.ory.sh/docs/ecosystem/configuring)
+section.
 
 ```yaml
 ## ORY Kratos Configuration


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/8042a8da0b42c9ff50deb9860249f95c756af18f.