### PR TITLE
fix: handle pagination and errors in the engines

### DIFF
--- a/internal/persistence/definitions.go
+++ b/internal/persistence/definitions.go
@@ -32,3 +32,5 @@ var (
 	ErrNamespaceUnknown   = errors.New("namespace unknown")
 	ErrMalformedPageToken = errors.New("malformed page token")
 )
+
+const PageTokenEnd = "no other page"

--- a/internal/persistence/sql/pagination_test.go
+++ b/internal/persistence/sql/pagination_test.go
@@ -13,11 +13,11 @@ import (
 
 func TestPaginationToken(t *testing.T) {
 	for i, tc := range []struct {
-		size           uint
+		size           int
 		token          string
 		expectedErr    error
-		expectedOffset uint
-		expectedLimit  uint
+		expectedOffset int
+		expectedLimit  int
 	}{
 		{
 			size:           10,

--- a/internal/persistence/sql/persister.go
+++ b/internal/persistence/sql/persister.go
@@ -34,7 +34,7 @@ type (
 
 const (
 	transactionContextKey contextKeys = "ongoing transaction"
-	defaultPageSize                   = 100
+	defaultPageSize       int         = 100
 )
 
 var (

--- a/internal/persistence/sql/persister.go
+++ b/internal/persistence/sql/persister.go
@@ -26,16 +26,15 @@ type (
 		namespaces namespace.Manager
 	}
 	internalPagination struct {
-		Offset uint
-		Limit  uint
+		Offset int
+		Limit  int
 	}
 	contextKeys string
 )
 
 const (
-	pageTokenEnd                      = "no other page"
 	transactionContextKey contextKeys = "ongoing transaction"
-	defaultPageSize       uint        = 100
+	defaultPageSize                   = 100
 )
 
 var (
@@ -101,7 +100,7 @@ func internalPaginationFromOptions(opts ...x.PaginationOptionSetter) (*internalP
 }
 
 func (p *internalPagination) parsePageToken(t string) error {
-	if t == pageTokenEnd {
+	if t == persistence.PageTokenEnd {
 		p.Limit = 0
 		p.Offset = 0
 		return nil
@@ -117,7 +116,7 @@ func (p *internalPagination) parsePageToken(t string) error {
 		return errors.WithStack(persistence.ErrMalformedPageToken)
 	}
 
-	p.Offset = uint(i)
+	p.Offset = int(i)
 	return nil
 }
 

--- a/internal/persistence/sql/relationtuples.go
+++ b/internal/persistence/sql/relationtuples.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ory/keto/internal/persistence"
+
 	"github.com/pkg/errors"
 
 	"github.com/ory/keto/internal/namespace"
@@ -71,7 +73,7 @@ func (p *Persister) GetRelationTuples(ctx context.Context, query *relationtuple.
 
 	pagination, err := internalPaginationFromOptions(options...)
 	if err != nil {
-		return nil, pageTokenEnd, err
+		return nil, persistence.PageTokenEnd, err
 	}
 
 	var (
@@ -120,7 +122,7 @@ func (p *Persister) GetRelationTuples(ctx context.Context, query *relationtuple.
 	if err := p.conn.
 		RawQuery(rawQuery, args...).
 		All(&res); err != nil {
-		return nil, pageTokenEnd, errors.WithStack(err)
+		return nil, persistence.PageTokenEnd, errors.WithStack(err)
 	}
 
 	internalRes := make([]*relationtuple.InternalRelationTuple, len(res))
@@ -130,13 +132,13 @@ func (p *Persister) GetRelationTuples(ctx context.Context, query *relationtuple.
 		var err error
 		internalRes[i], err = r.toInternal()
 		if err != nil {
-			return nil, pageTokenEnd, err
+			return nil, persistence.PageTokenEnd, err
 		}
 	}
 
 	nextPageToken := pagination.encodeNextPageToken()
 	if len(internalRes) == 0 {
-		nextPageToken = pageTokenEnd
+		nextPageToken = persistence.PageTokenEnd
 	}
 	return internalRes, nextPageToken, nil
 }

--- a/internal/relationtuple/read_server.go
+++ b/internal/relationtuple/read_server.go
@@ -20,7 +20,7 @@ func (h *handler) ListRelationTuples(ctx context.Context, req *acl.ListRelationT
 			Relation:  req.Query.Relation,
 			Subject:   SubjectFromProto(req.Query.Subject),
 		},
-		x.WithSize(uint(req.PageSize)),
+		x.WithSize(int(req.PageSize)),
 		x.WithToken(req.PageToken),
 	)
 	if err != nil {

--- a/internal/x/pagination.go
+++ b/internal/x/pagination.go
@@ -3,7 +3,7 @@ package x
 type (
 	paginationOptions struct {
 		Token string
-		Size  uint
+		Size  int
 	}
 	PaginationOptionSetter func(*paginationOptions) *paginationOptions
 )
@@ -15,7 +15,7 @@ func WithToken(t string) PaginationOptionSetter {
 	}
 }
 
-func WithSize(size uint) PaginationOptionSetter {
+func WithSize(size int) PaginationOptionSetter {
 	return func(opts *paginationOptions) *paginationOptions {
 		opts.Size = size
 		return opts


### PR DESCRIPTION
## Proposed changes

Until now the check and expand engines ignored everything beyond the first page. They now fully paginate results they get from the persister.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Further comments

This also fixes a small bug I found in the check engines. The `case=subject id next to subject set` test was added to prevent regression.