### PR TITLE
fix: check engine overwrote result in some cases

### DIFF
--- a/internal/check/engine.go
+++ b/internal/check/engine.go
@@ -56,6 +56,9 @@ func (e *Engine) subjectIsAllowed(ctx context.Context, requested *relationtuple.
 		if err != nil {
 			return false, err
 		}
+		if allowed {
+			return true, nil
+		}
 	}
 
 	return allowed, nil


### PR DESCRIPTION
## Related issue

Closes #405
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

As suggested, abort early.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Further comments

This was a regression issue. Tests where added now. Before some refactoring, the check engine did `or` all results: https://github.com/ory/keto/blob/185ee1e51bc4bcdee028f71fcaf207b7e342313b/internal/check/engine.go#L67
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
