### PR TITLE
fix: empty relationtuple list should not error

### DIFF
--- a/internal/expand/engine.go
+++ b/internal/expand/engine.go
@@ -2,10 +2,6 @@ package expand
 
 import (
 	"context"
-	"errors"
-
-	"github.com/ory/herodot"
-
 	"github.com/ory/keto/internal/x"
 
 	"github.com/ory/keto/internal/relationtuple"
@@ -53,7 +49,7 @@ func (e *Engine) BuildTree(ctx context.Context, subject relationtuple.Subject, r
 				},
 				x.WithToken(nextPage),
 			)
-			if errors.Is(err, herodot.ErrNotFound) {
+			if len(rels) == 0 {
 				return nil, nil
 			} else if err != nil {
 				return nil, err

--- a/internal/expand/engine.go
+++ b/internal/expand/engine.go
@@ -2,6 +2,7 @@ package expand
 
 import (
 	"context"
+
 	"github.com/ory/keto/internal/x"
 
 	"github.com/ory/keto/internal/relationtuple"

--- a/internal/persistence/sql/relationtuples.go
+++ b/internal/persistence/sql/relationtuples.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ory/herodot"
-
 	"github.com/gobuffalo/pop/v5"
 
 	"github.com/pkg/errors"
@@ -125,10 +123,6 @@ func (p *Persister) GetRelationTuples(ctx context.Context, query *relationtuple.
 		RawQuery(rawQuery, args...).
 		All(&res); err != nil {
 		return nil, x.PageTokenEnd, errors.WithStack(err)
-	}
-
-	if len(res) == 0 {
-		return nil, x.PageTokenEnd, errors.WithStack(herodot.ErrNotFound)
 	}
 
 	cutOff := 1

--- a/internal/relationtuple/manager_requirements.go
+++ b/internal/relationtuple/manager_requirements.go
@@ -240,5 +240,18 @@ func ManagerTest(t *testing.T, m Manager, addNamespace func(context.Context, *te
 			assert.Len(t, res, 1)
 			assert.Equal(t, notEncounteredTuples, res)
 		})
+
+		t.Run("case=empty list", func(t *testing.T) {
+			nspace := t.Name()
+			addNamespace(context.Background(), t, nspace)
+
+			res, nextPage, err := m.GetRelationTuples(context.Background(), &RelationQuery{
+				Namespace: nspace,
+			})
+
+			assert.NoError(t, err)
+			assert.Equal(t, res, []*InternalRelationTuple{})
+			assert.Equal(t, x.PageTokenEnd, nextPage)
+		})
 	})
 }


### PR DESCRIPTION
## Related issue
closes #439

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->
