### PR TITLE
chore: update repository template to 9c9e465a

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,9 @@ or the [ORY Chat](https://www.ory.sh/chat).
   [How can I become a part of the community?](#communication)
 
 - I would like to know what I am agreeing to when I contribute to ORY
-  Keto. Does ORY have
-  [a Contributors License Agreement?](https://cla-assistant.io/ory/)
+  Keto.
+  Does ORY have
+  [a Contributors License Agreement?](https://cla-assistant.io/ory/keto)
 
 - I would like updates about new versions of ORY Keto.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
@@ -112,10 +113,8 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-Check out
-[ORY Keto Discussions](https://github.com/ory/keto/discussions). This
-is a great place for in-depth discussions and lots of code examples, logs and
-similar data.
+Check out [ORY Keto Discussions](https://github.com/ory/keto/discussions). This is a great place for
+in-depth discussions and lots of code examples, logs and similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in
@@ -146,7 +145,7 @@ At least one review from a maintainer is required for all patches (even patches
 from maintainers).
 
 Before your contributions can be merged you need to sign our
-[Contributor License Agreement](https://cla-assistant.io/ory/).
+[Contributor License Agreement](https://cla-assistant.io/ory/keto).
 
 This agreement defines the terms under which your code is contributed to ORY.
 More specifically it declares that you have the right to, and actually do, grant
@@ -162,8 +161,8 @@ should be merged by the submitter after review.
 
 Please provide documentation when changing, removing, or adding features.
 Documentation resides in the project's
-[docs](https://github.com/ory/keto/tree/master/docs) folder. Generate API
-and configuration reference documentation using `cd docs; npm run gen`.
+[docs](https://github.com/ory/keto/tree/master/docs) folder. Generate API and
+configuration reference documentation using `cd docs; npm run gen`.
 
 For further instructions please head over to
 [docs/README.md](https://github.com/ory/keto/blob/master/README.md).
@@ -209,10 +208,10 @@ please include a note in your commit message explaining why.
 
 ```
 # First you clone the original repository
-git clone git@github.com:ory/Keto.git
+git clone git@github.com:ory/ory/keto.git
 
 # Next you add a git remote that is your fork:
-git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/Keto.git
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/ory/keto.git
 
 # Next you fetch the latest changes from origin for master:
 git fetch origin
@@ -248,8 +247,8 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY
-  Keto core team immediately.
+  member, please contact one of the channel ops or a member of the ORY Keto
+  core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Each mechanism is powered by a decision engine implemented on top of the
 The ORY community stands on the shoulders of individuals, companies, and
 maintainers. We thank everyone involved - from submitting bug reports and
 feature requests, to contributing patches, to sponsoring our work. Our community
-is 1000+ strong and growing rapidly. The ORY stack protects 1.200.000.000+ API
-requests every month with over 15.000+ active service nodes. We would have never
-been able to achieve this without each and everyone of you!
+is 1000+ strong and growing rapidly. The ORY stack protects 16.000.000.000+ API
+requests every month with over 250.000+ active service nodes. We would have
+never been able to achieve this without each and everyone of you!
 
 The following list represents companies that have accompanied us along the way
 and that have made outstanding contributions to our ecosystem. _If you think
 that your company deserves a spot here, reach out to
-<a href="mailto:office@ory.sh">office@ory.sh</a> now_!
+<a href="mailto:office-muc@ory.sh">office-muc@ory.sh</a> now_!
 
 **Please consider giving back by becoming a sponsor of our open source work on
 <a href="https://www.patreon.com/_ory">Patreon</a> or
@@ -237,8 +237,9 @@ deal with: Self-service Login and Registration, Multi-Factor Authentication
 ### ORY Hydra: OAuth2 & OpenID Connect Server
 
 [ORY Hydra](https://github.com/ory/hydra) is an OpenID Certified™ OAuth2 and
-OpenID Connect Provider can connect to any existing identity database (LDAP, AD,
-KeyCloak, PHP+MySQL, ...) and user interface.
+OpenID Connect Provider which easily connects to any existing identity system by
+writing a tiny "bridge" application. Gives absolute control over user interface
+and user experience flows.
 
 ### ORY Oathkeeper: Identity & Access Proxy
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -73,7 +73,8 @@ the [ORY Chat](https://www.ory.sh/chat).
   [How can I become a part of the community?](#communication)
 
 - I would like to know what I am agreeing to when I contribute to ORY Keto. Does
-  ORY have [a Contributors License Agreement?](https://cla-assistant.io/ory/)
+  ORY have
+  [a Contributors License Agreement?](https://cla-assistant.io/ory/keto)
 
 - I would like updates about new versions of ORY Keto.
   [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
@@ -147,7 +148,7 @@ At least one review from a maintainer is required for all patches (even patches
 from maintainers).
 
 Before your contributions can be merged you need to sign our
-[Contributor License Agreement](https://cla-assistant.io/ory/).
+[Contributor License Agreement](https://cla-assistant.io/ory/keto).
 
 This agreement defines the terms under which your code is contributed to ORY.
 More specifically it declares that you have the right to, and actually do, grant
@@ -210,10 +211,10 @@ please include a note in your commit message explaining why.
 
 ```
 # First you clone the original repository
-git clone git@github.com:ory/Keto.git
+git clone git@github.com:ory/ory/keto.git
 
 # Next you add a git remote that is your fork:
-git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/Keto.git
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/ory/keto.git
 
 # Next you fetch the latest changes from origin for master:
 git fetch origin

--- a/docs/docs/engines/acp-ory.md
+++ b/docs/docs/engines/acp-ory.md
@@ -500,7 +500,8 @@ The following access request would be denied.
 
 ### Time Interval Condition
 
-This condition check if a request is within some predefined interval. It accepts any number interval [after, before).
+This condition check if a request is within some predefined interval. It accepts
+any number interval [after, before).
 
 ```json
 {
@@ -520,6 +521,7 @@ This condition check if a request is within some predefined interval. It accepts
   }
 }
 ```
+
 The following access request would be allowed.
 
 ```json

--- a/docs/docs/sdk/index.md
+++ b/docs/docs/sdk/index.md
@@ -20,7 +20,9 @@ repositories:
 - [Dart](https://pub.dev/packages/ory_keto_client)
 - [Go](https://github.com/ory/keto-client-go)
 - [Java](https://search.maven.org/artifact/sh.ory.keto/keto-client)
-- [JavaScript](https://www.npmjs.com/package/@ory/keto-client) with TypeScript definitions and compatible with: NodeJS, ReactJS, AnuglarJS, Vue.js, and many more.
+- [JavaScript](https://www.npmjs.com/package/@ory/keto-client) with TypeScript
+  definitions and compatible with: NodeJS, ReactJS, AnuglarJS, Vue.js, and many
+  more.
 - [PHP](https://packagist.org/packages/ory/keto-client)
 - [Python](https://pypi.org/project/ory-keto-client/)
 - [Ruby](https://rubygems.org/gems/ory-keto-client)


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/9c9e465a1a1c06e4fe353464672c9069f1f11f49.