### PR TITLE
fix: use errors.WithStack everywhere

### DIFF
--- a/internal/driver/config/namespace_watcher.go
+++ b/internal/driver/config/namespace_watcher.go
@@ -36,7 +36,7 @@ var _ namespace.Manager = &NamespaceWatcher{}
 func NewNamespaceWatcher(ctx context.Context, l *logrusx.Logger, target string) (*NamespaceWatcher, error) {
 	u, err := urlx.Parse(target)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	nw := NamespaceWatcher{
@@ -49,7 +49,11 @@ func NewNamespaceWatcher(ctx context.Context, l *logrusx.Logger, target string) 
 	var w watcherx.Watcher
 
 	info, err := os.Stat(u.Path)
-	if err == nil && info.IsDir() {
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if info.IsDir() {
 		w, err = watcherx.WatchDirectory(ctx, u.Path, nw.ec)
 	} else {
 		w, err = watcherx.Watch(ctx, u, nw.ec)
@@ -62,7 +66,7 @@ func NewNamespaceWatcher(ctx context.Context, l *logrusx.Logger, target string) 
 	// trigger initial load
 	done, err := w.DispatchNow()
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 
 	initialEventsProcessed := make(chan struct{})

--- a/internal/expand/engine.go
+++ b/internal/expand/engine.go
@@ -50,10 +50,10 @@ func (e *Engine) BuildTree(ctx context.Context, subject relationtuple.Subject, r
 				},
 				x.WithToken(nextPage),
 			)
-			if len(rels) == 0 {
-				return nil, nil
-			} else if err != nil {
+			if err != nil {
 				return nil, err
+			} else if len(rels) == 0 {
+				return nil, nil
 			}
 
 			if restDepth <= 1 {


### PR DESCRIPTION
## Related issue

Closes #437 

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

Fixed all occurrences found using the search pattern `return.* err\n`.
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->