### PR TITLE
chore: update repository template to c7a2e1f9

### DIFF
--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,0 +1,1 @@
+*       @ory/maintainers

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ORY Community
-    url: https://community.ory.sh/
-    about: Please ask and answer questions here.
+  - name: ORY Keto Forum
+    url: https://github.com/ory/keto/discussions
+    about: Please ask and answer questions here, show your implementations and discuss ideas.
   - name: ORY Chat
     url: https://www.ory.sh/chat
     about: Hang out with other ORY community members and ask and answer questions.
-  - name: ORY Enterprise Contact
-    url: https://www.ory.sh/contact
-    about: Jared will help you with your enterprise-related inquiries.
+  - name: ORY Support for Business
+    url: https://github.com/ory/open-source-support/blob/master/README.md
+    about: Buy professional support for ORY Keto.

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,15 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+assignees:
+  - ory/maintainers
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+addAssignees: author

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`)
 If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
 chance substantial changes will be requested or that the changes will be rejected.
 
-You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
+You can discuss changes with maintainers either in the Github Discusssions in this repository or
 join the [ORY Chat](https://www.ory.sh/chat).
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,49 +4,133 @@ Thank you for contributing changes to this document! Because we use a central re
 to synchronize this file across all our repositories, make sure to make your edits
 in the correct file, which you can find here:
 
-https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
+https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING.md
 
 -->
 
-# Contributing to ORY {{Project}}
+# Contributing to ORY Keto
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
+- [FAQ](#faq)
+- [How can I contribute?](#how-can-i-contribute)
+- [Communication](#communication)
 - [Contributing Code](#contributing-code)
+- [Documentation](#documentation)
 - [Disclosing vulnerabilities](#disclosing-vulnerabilities)
 - [Code Style](#code-style)
-- [Documentation](#documentation)
 - [Pull request procedure](#pull-request-procedure)
-- [Communication](#communication)
+  - [Working with Forks](#working-with-forks)
 - [Conduct](#conduct)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Introduction
 
-Please note: We take ORY {{Project}}'s security and our users' trust very
-seriously. If you believe you have found a security issue in ORY {{Project}},
-please responsibly disclose by contacting us at office@ory.sh.
+There are many ways in which you can contribute, beyond writing code. The goal
+of this document is to provide a high-level overview of how you can get
+involved.
 
-First: if you're unsure or afraid of anything, just ask or submit the issue or
-pull request anyways. You won't be yelled at for giving it your best effort. The
-worst that can happen is that you'll be politely asked to change something. We
-appreciate any sort of contributions, and don't want a wall of rules to get in
-the way of that.
+_Please note_: We take ORY Keto's security and our users' trust very
+seriously. If you believe you have found a security issue in ORY Keto,
+please responsibly disclose by contacting us at security@ory.sh.
+
+First: As a potential contributor, your changes and ideas are welcome at any
+hour of the day or night, weekdays, weekends, and holidays. Please do not ever
+hesitate to ask a question or send a pull request.
+
+If you are unsure, just ask or submit the issue or pull request anyways. You
+won't be yelled at for giving it your best effort. The worst that can happen is
+that you'll be politely asked to change something. We appreciate any sort of
+contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY {{Project}}'s normal direction. A great way to
-do this is via the [ORY Community](https://community.ory.sh/) or join the
-[ORY Chat](https://www.ory.sh/chat).
+won't clash or be obviated by ORY
+Keto's normal direction. A great way to
+do this is via
+[ORY Keto Discussions](https://github.com/ory/keto/discussions)
+or the [ORY Chat](https://www.ory.sh/chat).
+
+## FAQ
+
+- I am new to the community. Where can I find the
+  [ORY Community Code of Conduct?](https://github.com/ory/keto/blob/master/CODE_OF_CONDUCT.md)
+
+- I have a question. Where can I get
+  [answers to questions regarding ORY Keto?](#communication)
+
+- I would like to contribute but I am not sure how. Are there
+  [easy ways to contribute?](#how-can-i-contribute)
+  [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
+
+- I want to talk to other ORY Keto users.
+  [How can I become a part of the community?](#communication)
+
+- I would like to know what I am agreeing to when I contribute to ORY
+  Keto.
+  Does ORY have
+  [a Contributors License Agreement?](https://cla-assistant.io/ory/keto)
+
+- I would like updates about new versions of ORY Keto.
+  [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
+
+## How can I contribute?
+
+If you want to start contributing code right away, we have a
+[list of good first issues](https://github.com/ory/keto/labels/good%20first%20issue).
+
+There are many other ways you can contribute without writing any code. Here are
+a few things you can do to help out:
+
+- **Give us a star.** It may not seem like much, but it really makes a
+  difference. This is something that everyone can do to help out ORY Keto.
+  Github stars help the project gain visibility and stand out.
+
+- **Join the community.** Sometimes helping people can be as easy as listening
+  to their problems and offering a different perspective. Join our Slack, have a
+  look at discussions in the forum and take part in our weekly hangout. More
+  info on this in [Communication](#communication).
+
+- **Helping with open issues.** We have a lot of open issues for ORY Keto
+  and some of them may lack necessary information, some are duplicates of older
+  issues. You can help out by guiding people through the process of filling out
+  the issue template, asking for clarifying information, or pointing them to
+  existing issues that match their description of the problem.
+
+- **Reviewing documentation changes.** Most documentation just needs a review
+  for proper spelling and grammar. If you think a document can be improved in
+  any way, feel free to hit the `edit` button at the top of the page. More info
+  on contributing to documentation here.
+
+- **Help with tests.** Some pull requests may lack proper tests or test plans.
+  These are needed for the change to be implemented safely.
+
+## Communication
+
+We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
+questions, discuss bugs and feature requests, talk to other users of ORY, etc.
+
+Check out [ORY Keto Discussions](https://github.com/ory/keto/discussions). This is a great place for
+in-depth discussions and lots of code examples, logs and similar data.
+
+You can also join our community hangout, if you want to speak to the ORY team
+directly or ask some questions. You can find more info on the hangouts in
+[Slack](https://www.ory.sh/chat).
+
+If you want to receive regular notifications about updates to ORY Keto,
+consider joining the mailing list. We will _only_ send you vital information on
+the projects that you are interested in.
+
+Also [follow us on twitter](https://twitter.com/orycorp).
 
 ## Contributing Code
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY {{Project}}'s
+before getting started to ensure your work is consistent with ORY Keto's
 roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
@@ -54,14 +138,34 @@ contributors get reviewed**. After a pull request is made other contributors
 will offer feedback, and if the patch passes review a maintainer will accept it
 with a comment. When pull requests fail testing, authors are expected to update
 their pull requests to address the failures until the tests pass and the pull
-request merges successfully.
+request merges successfully. Look here for more info on the
+[Pull request procedure](#pull-request-procedure).
 
 At least one review from a maintainer is required for all patches (even patches
 from maintainers).
 
+Before your contributions can be merged you need to sign our
+[Contributor License Agreement](https://cla-assistant.io/ory/keto).
+
+This agreement defines the terms under which your code is contributed to ORY.
+More specifically it declares that you have the right to, and actually do, grant
+us the rights to use your contribution. You can see the Apache 2.0 license under
+which our projects are published
+[here](https://github.com/ory/meta/blob/master/LICENSE).
+
 Reviewers should leave a "LGTM" comment once they are satisfied with the patch.
 If the patch was submitted by a maintainer with write access, the pull request
 should be merged by the submitter after review.
+
+## Documentation
+
+Please provide documentation when changing, removing, or adding features.
+Documentation resides in the project's
+[docs](https://github.com/ory/keto/tree/master/docs) folder. Generate API and
+configuration reference documentation using `cd docs; npm run gen`.
+
+For further instructions please head over to
+[docs/README.md](https://github.com/ory/keto/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 
@@ -75,46 +179,6 @@ Please follow these guidelines when formatting source code:
 - Go code should match the output of `gofmt -s` and pass `golangci-lint run`.
 - NodeJS and JavaScript code should be prettified using `npm run format` where
   appropriate.
-
-## Documentation
-
-Please provide documentation when changing, removing, or adding features.
-Documentation resides in the project's `docs` folder.
-
-In cases where a project does not have a `docs` folder check the README for
-instructions.
-
-The commands listed below work exclusively for projects with a `docs` folder
-
-### Develop
-
-To change the documentation locally, you need NodeJS installed and the project
-checked out locally. Next, `cd` into `docs` and install the dependencies:
-
-```shell script
-$ cd docs
-$ npm install
-```
-
-#### Start
-
-To start a local development server with hot reloading, run:
-
-```shell script
-$ npm start
-```
-
-This command opens up a browser window. Please note that changes to the sidebar
-are not hot-reloaded and require a restart of the command.
-
-#### Build
-
-The `npm build` generates static content into the `build` directory and can be
-served using any static contents hosting service.
-
-```shell script
-$ npm build
-```
 
 ## Pull request procedure
 
@@ -140,39 +204,32 @@ Normally, all pull requests must include tests that test your change.
 Occasionally, a change will be very difficult to test for. In those cases,
 please include a note in your commit message explaining why.
 
-## How We Organize Our Work
+### Working with Forks
 
-All repositories in the [ORY organization](https://github.com/ory) have their
-issues and pull requests monitored in the
-[ORY Monitoring Board](https://github.com/orgs/ory/projects/9). This allows for
-a transparent backlog of unanswered issues and pull requests across the
-ecosystem from those who are allowed to merge pull requests to the main branch.
+```
+# First you clone the original repository
+git clone git@github.com:ory/ory/keto.git
 
-The process is as follows:
+# Next you add a git remote that is your fork:
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/ory/keto.git
 
-1. _Cards_ represent open issues and pull requests and are automatically
-   assigned to the **Triage** column if the author is not one of the maintainers
-   and no maintainer has answered yet.
-2. A maintainer assigns the issue or pull request to someone or adds the label
-   _help wanted_ which moves the card to **Requires Action**.
-3. If a maintainer leaves a comment or review, the card moves to **Pending
-   Reply**, implying that the original author needs to do something (e.g.
-   implement a change, explain something in more detail, ...).
-4. If a non-maintainer pushes changes to the pull request or leaves a comment,
-   the card moves back to **Requires Action**.
-5. If a card stays inactive for 60 days or more days, we assume that public
-   interest in the issue or change has waned, **archiving** the card.
-6. If the issue is closed or the pull request merged or closed, the card is
-   **archived** as well.
+# Next you fetch the latest changes from origin for master:
+git fetch origin
+git checkout master
+git pull --rebase
 
-We try our best to answer all issues and review all pull requests and hope that
-this transparent way of keeping a backlog helps you better understand how heavy
-the workload is.
+# Next you create a new feature branch off of master:
+git checkout my-feature-branch
 
-## Communication
+# Now you do your work and commit your changes:
+git add -A
+git commit -a -m "fix: this is the subject line" -m "This is the body line. Closes #123"
 
-We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
-questions, discuss bugs, etc.
+# And the last step is pushing this to your fork
+git push -u fork my-feature-branch
+```
+
+Now go to the project's GitHub Pull Request page and click "New pull request"
 
 ## Conduct
 
@@ -190,8 +247,8 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY
-  {{Project}} core team immediately.
+  member, please contact one of the channel ops or a member of the ORY Keto
+  core team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -9,64 +9,166 @@ Thank you for contributing changes to this document! Because we use a central re
 to synchronize this file across all our repositories, make sure to make your edits
 in the correct file, which you can find here:
 
-https://github.com/ory/meta/blob/master/templates/repository/CONTRIBUTING.md
+https://github.com/ory/meta/blob/master/templates/repository/common/CONTRIBUTING.md
 
 -->
 
-# Contributing to ORY {{Project}}
+# Contributing to ORY Keto
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Introduction](#introduction)
+- [FAQ](#faq)
+- [How can I contribute?](#how-can-i-contribute)
+- [Communication](#communication)
 - [Contributing Code](#contributing-code)
+- [Documentation](#documentation)
 - [Disclosing vulnerabilities](#disclosing-vulnerabilities)
 - [Code Style](#code-style)
-- [Documentation](#documentation)
 - [Pull request procedure](#pull-request-procedure)
-- [Communication](#communication)
+  - [Working with Forks](#working-with-forks)
 - [Conduct](#conduct)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Introduction
 
-Please note: We take ORY {{Project}}'s security and our users' trust very
-seriously. If you believe you have found a security issue in ORY {{Project}},
-please responsibly disclose by contacting us at office@ory.sh.
+There are many ways in which you can contribute, beyond writing code. The goal
+of this document is to provide a high-level overview of how you can get
+involved.
 
-First: if you're unsure or afraid of anything, just ask or submit the issue or
-pull request anyways. You won't be yelled at for giving it your best effort. The
-worst that can happen is that you'll be politely asked to change something. We
-appreciate any sort of contributions, and don't want a wall of rules to get in
-the way of that.
+_Please note_: We take ORY Keto's security and our users' trust very seriously.
+If you believe you have found a security issue in ORY Keto, please responsibly
+disclose by contacting us at security@ory.sh.
+
+First: As a potential contributor, your changes and ideas are welcome at any
+hour of the day or night, weekdays, weekends, and holidays. Please do not ever
+hesitate to ask a question or send a pull request.
+
+If you are unsure, just ask or submit the issue or pull request anyways. You
+won't be yelled at for giving it your best effort. The worst that can happen is
+that you'll be politely asked to change something. We appreciate any sort of
+contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY {{Project}}'s normal direction. A great way to
-do this is via the [ORY Community](https://community.ory.sh/) or join the
-[ORY Chat](https://www.ory.sh/chat).
+won't clash or be obviated by ORY Keto's normal direction. A great way to do
+this is via [ORY Keto Discussions](https://github.com/ory/keto/discussions) or
+the [ORY Chat](https://www.ory.sh/chat).
+
+## FAQ
+
+- I am new to the community. Where can I find the
+  [ORY Community Code of Conduct?](https://github.com/ory/keto/blob/master/CODE_OF_CONDUCT.md)
+
+- I have a question. Where can I get
+  [answers to questions regarding ORY Keto?](#communication)
+
+- I would like to contribute but I am not sure how. Are there
+  [easy ways to contribute?](#how-can-i-contribute)
+  [Or good first issues?](https://github.com/search?l=&o=desc&q=label%3A%22help+wanted%22+label%3A%22good+first+issue%22+is%3Aopen+user%3Aory+user%3Aory-corp&s=updated&type=Issues)
+
+- I want to talk to other ORY Keto users.
+  [How can I become a part of the community?](#communication)
+
+- I would like to know what I am agreeing to when I contribute to ORY Keto. Does
+  ORY have
+  [a Contributors License Agreement?](https://cla-assistant.io/ory/keto)
+
+- I would like updates about new versions of ORY Keto.
+  [How are new releases announced?](https://ory.us10.list-manage.com/subscribe?u=ffb1a878e4ec6c0ed312a3480&id=f605a41b53)
+
+## How can I contribute?
+
+If you want to start contributing code right away, we have a
+[list of good first issues](https://github.com/ory/keto/labels/good%20first%20issue).
+
+There are many other ways you can contribute without writing any code. Here are
+a few things you can do to help out:
+
+- **Give us a star.** It may not seem like much, but it really makes a
+  difference. This is something that everyone can do to help out ORY Keto.
+  Github stars help the project gain visibility and stand out.
+
+- **Join the community.** Sometimes helping people can be as easy as listening
+  to their problems and offering a different perspective. Join our Slack, have a
+  look at discussions in the forum and take part in our weekly hangout. More
+  info on this in [Communication](#communication).
+
+- **Helping with open issues.** We have a lot of open issues for ORY Keto and
+  some of them may lack necessary information, some are duplicates of older
+  issues. You can help out by guiding people through the process of filling out
+  the issue template, asking for clarifying information, or pointing them to
+  existing issues that match their description of the problem.
+
+- **Reviewing documentation changes.** Most documentation just needs a review
+  for proper spelling and grammar. If you think a document can be improved in
+  any way, feel free to hit the `edit` button at the top of the page. More info
+  on contributing to documentation here.
+
+- **Help with tests.** Some pull requests may lack proper tests or test plans.
+  These are needed for the change to be implemented safely.
+
+## Communication
+
+We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
+questions, discuss bugs and feature requests, talk to other users of ORY, etc.
+
+Check out [ORY Keto Discussions](https://github.com/ory/keto/discussions). This
+is a great place for in-depth discussions and lots of code examples, logs and
+similar data.
+
+You can also join our community hangout, if you want to speak to the ORY team
+directly or ask some questions. You can find more info on the hangouts in
+[Slack](https://www.ory.sh/chat).
+
+If you want to receive regular notifications about updates to ORY Keto, consider
+joining the mailing list. We will _only_ send you vital information on the
+projects that you are interested in.
+
+Also [follow us on twitter](https://twitter.com/orycorp).
 
 ## Contributing Code
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY {{Project}}'s
-roadmap and architecture.
+before getting started to ensure your work is consistent with ORY Keto's roadmap
+and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
 contributors get reviewed**. After a pull request is made other contributors
 will offer feedback, and if the patch passes review a maintainer will accept it
 with a comment. When pull requests fail testing, authors are expected to update
 their pull requests to address the failures until the tests pass and the pull
-request merges successfully.
+request merges successfully. Look here for more info on the
+[Pull request procedure](#pull-request-procedure).
 
 At least one review from a maintainer is required for all patches (even patches
 from maintainers).
 
+Before your contributions can be merged you need to sign our
+[Contributor License Agreement](https://cla-assistant.io/ory/keto).
+
+This agreement defines the terms under which your code is contributed to ORY.
+More specifically it declares that you have the right to, and actually do, grant
+us the rights to use your contribution. You can see the Apache 2.0 license under
+which our projects are published
+[here](https://github.com/ory/meta/blob/master/LICENSE).
+
 Reviewers should leave a "LGTM" comment once they are satisfied with the patch.
 If the patch was submitted by a maintainer with write access, the pull request
 should be merged by the submitter after review.
+
+## Documentation
+
+Please provide documentation when changing, removing, or adding features.
+Documentation resides in the project's
+[docs](https://github.com/ory/keto/tree/master/docs) folder. Generate API and
+configuration reference documentation using `cd docs; npm run gen`.
+
+For further instructions please head over to
+[docs/README.md](https://github.com/ory/keto/blob/master/README.md).
 
 ## Disclosing vulnerabilities
 
@@ -80,46 +182,6 @@ Please follow these guidelines when formatting source code:
 - Go code should match the output of `gofmt -s` and pass `golangci-lint run`.
 - NodeJS and JavaScript code should be prettified using `npm run format` where
   appropriate.
-
-## Documentation
-
-Please provide documentation when changing, removing, or adding features.
-Documentation resides in the project's `docs` folder.
-
-In cases where a project does not have a `docs` folder check the README for
-instructions.
-
-The commands listed below work exclusively for projects with a `docs` folder
-
-### Develop
-
-To change the documentation locally, you need NodeJS installed and the project
-checked out locally. Next, `cd` into `docs` and install the dependencies:
-
-```shell script
-$ cd docs
-$ npm install
-```
-
-#### Start
-
-To start a local development server with hot reloading, run:
-
-```shell script
-$ npm start
-```
-
-This command opens up a browser window. Please note that changes to the sidebar
-are not hot-reloaded and require a restart of the command.
-
-#### Build
-
-The `npm build` generates static content into the `build` directory and can be
-served using any static contents hosting service.
-
-```shell script
-$ npm build
-```
 
 ## Pull request procedure
 
@@ -145,39 +207,32 @@ Normally, all pull requests must include tests that test your change.
 Occasionally, a change will be very difficult to test for. In those cases,
 please include a note in your commit message explaining why.
 
-## How We Organize Our Work
+### Working with Forks
 
-All repositories in the [ORY organization](https://github.com/ory) have their
-issues and pull requests monitored in the
-[ORY Monitoring Board](https://github.com/orgs/ory/projects/9). This allows for
-a transparent backlog of unanswered issues and pull requests across the
-ecosystem from those who are allowed to merge pull requests to the main branch.
+```
+# First you clone the original repository
+git clone git@github.com:ory/ory/keto.git
 
-The process is as follows:
+# Next you add a git remote that is your fork:
+git remote add fork git@github.com:<YOUR-GITHUB-USERNAME-HERE>/ory/keto.git
 
-1. _Cards_ represent open issues and pull requests and are automatically
-   assigned to the **Triage** column if the author is not one of the maintainers
-   and no maintainer has answered yet.
-2. A maintainer assigns the issue or pull request to someone or adds the label
-   _help wanted_ which moves the card to **Requires Action**.
-3. If a maintainer leaves a comment or review, the card moves to **Pending
-   Reply**, implying that the original author needs to do something (e.g.
-   implement a change, explain something in more detail, ...).
-4. If a non-maintainer pushes changes to the pull request or leaves a comment,
-   the card moves back to **Requires Action**.
-5. If a card stays inactive for 60 days or more days, we assume that public
-   interest in the issue or change has waned, **archiving** the card.
-6. If the issue is closed or the pull request merged or closed, the card is
-   **archived** as well.
+# Next you fetch the latest changes from origin for master:
+git fetch origin
+git checkout master
+git pull --rebase
 
-We try our best to answer all issues and review all pull requests and hope that
-this transparent way of keeping a backlog helps you better understand how heavy
-the workload is.
+# Next you create a new feature branch off of master:
+git checkout my-feature-branch
 
-## Communication
+# Now you do your work and commit your changes:
+git add -A
+git commit -a -m "fix: this is the subject line" -m "This is the body line. Closes #123"
 
-We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
-questions, discuss bugs, etc.
+# And the last step is pushing this to your fork
+git push -u fork my-feature-branch
+```
+
+Now go to the project's GitHub Pull Request page and click "New pull request"
 
 ## Conduct
 
@@ -195,8 +250,8 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY
-  {{Project}} core team immediately.
+  member, please contact one of the channel ops or a member of the ORY Keto core
+  team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 

--- a/proto/ory/keto/acl/v1alpha1/acl_pb.js
+++ b/proto/ory/keto/acl/v1alpha1/acl_pb.js
@@ -2,14 +2,11 @@
 /**
  * @fileoverview
  * @enhanceable
- * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
-/* eslint-disable */
-// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/proto/ory/keto/acl/v1alpha1/check_service_pb.js
+++ b/proto/ory/keto/acl/v1alpha1/check_service_pb.js
@@ -2,14 +2,11 @@
 /**
  * @fileoverview
  * @enhanceable
- * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
-/* eslint-disable */
-// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/proto/ory/keto/acl/v1alpha1/expand_service_pb.js
+++ b/proto/ory/keto/acl/v1alpha1/expand_service_pb.js
@@ -2,14 +2,11 @@
 /**
  * @fileoverview
  * @enhanceable
- * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
-/* eslint-disable */
-// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/proto/ory/keto/acl/v1alpha1/read_service_pb.js
+++ b/proto/ory/keto/acl/v1alpha1/read_service_pb.js
@@ -2,14 +2,11 @@
 /**
  * @fileoverview
  * @enhanceable
- * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
-/* eslint-disable */
-// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/proto/ory/keto/acl/v1alpha1/version_pb.js
+++ b/proto/ory/keto/acl/v1alpha1/version_pb.js
@@ -2,14 +2,11 @@
 /**
  * @fileoverview
  * @enhanceable
- * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
-/* eslint-disable */
-// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/proto/ory/keto/acl/v1alpha1/write_service_pb.js
+++ b/proto/ory/keto/acl/v1alpha1/write_service_pb.js
@@ -2,14 +2,11 @@
 /**
  * @fileoverview
  * @enhanceable
- * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
-/* eslint-disable */
-// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/c7a2e1f9ac8e52f80278670c47aa6a562872ebc5.