### PR TITLE
chore: update repository template to f2365e3d

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ There are many ways in which you can contribute, beyond writing code. The goal
 of this document is to provide a high-level overview of how you can get
 involved.
 
-_Please note_: We take ORY Keto's security and our users' trust very
-seriously. If you believe you have found a security issue in ORY Keto,
-please responsibly disclose by contacting us at security@ory.sh.
+_Please note_: We take ORY Keto's security and our users' trust very seriously.
+If you believe you have found a security issue in ORY Keto, please responsibly
+disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
 hour of the day or night, weekdays, weekends, and holidays. Please do not ever
@@ -48,11 +48,9 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by ORY
-Keto's normal direction. A great way to
-do this is via
-[ORY Keto Discussions](https://github.com/ory/keto/discussions)
-or the [ORY Chat](https://www.ory.sh/chat).
+won't clash or be obviated by ORY Keto's normal direction. A great way to do
+this is via [ORY Keto Discussions](https://github.com/ory/keto/discussions) or
+the [ORY Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
@@ -69,9 +67,8 @@ or the [ORY Chat](https://www.ory.sh/chat).
 - I want to talk to other ORY Keto users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to ORY
-  Keto.
-  Does ORY have
+- I would like to know what I am agreeing to when I contribute to ORY Keto. Does
+  ORY have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/keto)
 
 - I would like updates about new versions of ORY Keto.
@@ -94,8 +91,8 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for ORY Keto
-  and some of them may lack necessary information, some are duplicates of older
+- **Helping with open issues.** We have a lot of open issues for ORY Keto and
+  some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
   existing issues that match their description of the problem.
@@ -113,16 +110,17 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of ORY, etc.
 
-Check out [ORY Keto Discussions](https://github.com/ory/keto/discussions). This is a great place for
-in-depth discussions and lots of code examples, logs and similar data.
+Check out [ORY Keto Discussions](https://github.com/ory/keto/discussions). This
+is a great place for in-depth discussions and lots of code examples, logs and
+similar data.
 
 You can also join our community hangout, if you want to speak to the ORY team
 directly or ask some questions. You can find more info on the hangouts in
 [Slack](https://www.ory.sh/chat).
 
-If you want to receive regular notifications about updates to ORY Keto,
-consider joining the mailing list. We will _only_ send you vital information on
-the projects that you are interested in.
+If you want to receive regular notifications about updates to ORY Keto, consider
+joining the mailing list. We will _only_ send you vital information on the
+projects that you are interested in.
 
 Also [follow us on twitter](https://twitter.com/orycorp).
 
@@ -130,8 +128,8 @@ Also [follow us on twitter](https://twitter.com/orycorp).
 
 Unless you are fixing a known bug, we **strongly** recommend discussing it with
 the core team via a GitHub issue or [in our chat](https://www.ory.sh/chat)
-before getting started to ensure your work is consistent with ORY Keto's
-roadmap and architecture.
+before getting started to ensure your work is consistent with ORY Keto's roadmap
+and architecture.
 
 All contributions are made via pull request. Note that **all patches from all
 contributors get reviewed**. After a pull request is made other contributors
@@ -247,8 +245,8 @@ community a safe place for you and we've got your back.
   marginalized groups.
 - Private harassment is also unacceptable. No matter who you are, if you feel
   you have been or are being harassed or made uncomfortable by a community
-  member, please contact one of the channel ops or a member of the ORY Keto
-  core team immediately.
+  member, please contact one of the channel ops or a member of the ORY Keto core
+  team immediately.
 - Likewise any spamming, trolling, flaming, baiting or other attention-stealing
   behaviour is not welcome.
 


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/f2365e3dd9002b33f07a5f96a7264622e7841656.