### PR TITLE
ci: fix npm pack failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,9 @@ jobs:
       - image: cimg/go:1.16-node
     steps:
       - checkout
-      - run: sudo npm i -g npm@7
+
+      # https://github.com/npm/cli/issues/3132
+      - run: sudo npm i -g npm@7.10.0
 
       - go/load-cache
       - go/mod-download


### PR DESCRIPTION
## Related issue
See https://github.com/npm/cli/issues/3132
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

pin npm to 7.10.0 for now
