### PR TITLE
chore: update docusaurus template

### DIFF
--- a/docs/contrib/sidebar.js
+++ b/docs/contrib/sidebar.js
@@ -52,7 +52,9 @@ const toHref = (slug, node) => {
   return {
     label: fm.data.title,
     type: 'link',
-    href: `https://www.ory.sh/${slug}/docs/next/${fm.data.slug || node}`
+    href: `https://www.ory.sh/${slug}/docs/${slug !== 'docs' ? 'next/' : ''}${
+      fm.data.slug || node
+    }`
   }
 }
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "docusaurus-template",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "2.0.0-alpha.73",


### PR DESCRIPTION
Updated docusaurus template to current https://github.com/ory/docusaurus-template.