### PR TITLE
fix: update the version of './contrib/cat-videos-example/docker-compose.yml'

### DIFF
--- a/contrib/cat-videos-example/docker-compose.yml
+++ b/contrib/cat-videos-example/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 
 services:
   keto:


### PR DESCRIPTION
## Related issue

I got the following message when I tried to run "cat videos example" in [the way this guide explains](https://www.ory.sh/keto/docs/quickstart):

```sh
$ git clone git@github.com:ory/keto.git && cd keto
(blah blah)
$ docker-compose -f contrib/cat-videos-example/docker-compose.yml up --build
ERROR: The Compose file './contrib/cat-videos-example/docker-compose.yml' is invalid because:
services.keto.volumes contains an invalid type, it should be a string
services.keto-init.volumes contains an invalid type, it should be a string
```

This issue was originally the one reported in the pull request #549, and the pull request fixed the issue of `./docker-compose-postgres.yml` indeed. However, `./contrib/cat-videos-example/docker-compose.yml` still seems broken.

## Proposed changes

Update `version: '3'` to `version: '3.2'` as suggested in #549 .

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further comments

