### PR TITLE
feat: support config file namespace validation

### DIFF
--- a/cmd/namespace/validate.go
+++ b/cmd/namespace/validate.go
@@ -5,25 +5,43 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/ory/keto/internal/driver/config"
-
-	"github.com/ory/x/jsonschemax"
-
 	"github.com/ory/jsonschema/v3"
 	"github.com/ory/x/cmdx"
+	"github.com/ory/x/configx"
+	"github.com/ory/x/jsonschemax"
+	"github.com/ory/x/logrusx"
 	"github.com/segmentio/objconv/yaml"
 	"github.com/spf13/cobra"
 
+	"github.com/ory/keto/internal/driver/config"
 	"github.com/ory/keto/internal/namespace"
 )
 
 func NewValidateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "validate <namespace.yml> [<namespace2.yml> ...]",
-		Args:  cobra.MinimumNArgs(1),
-		Short: "Validate namespace files",
-		Long:  "Validate one or more namespace yaml files and get human readable errors. Useful for debugging.",
+		Use:   "validate <namespace.yml> [<namespace2.yml> ...] | validate -c <config.yaml>",
+		Short: "Validate namespace definitions",
+		Long: `validate
+Validates namespace definitions. Parses namespace yaml files or configuration
+files passed via the configuration flag. Returns human readable errors. Useful for
+debugging.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cfFlag := cmd.Flag(configx.FlagConfig)
+			if cfFlag.Changed {
+				cfiles, err := cmd.Flags().GetStringSlice(configx.FlagConfig)
+				if err != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Failed to read config command line flag\n%+v\n", err)
+					return cmdx.FailSilently(cmd)
+				}
+				for _, fn := range cfiles {
+					err := validateConfigFile(cmd, fn)
+					if err != nil {
+						return err
+					}
+				}
+			}
+
+			// user passed a list of namespace files
 			for _, fn := range args {
 				_, err := validateNamespaceFile(cmd, fn)
 				if err != nil {
@@ -43,7 +61,7 @@ var configSchema *jsonschema.Schema
 
 const schemaPath = "github.com/ory/keto/.schema/config.schema.json"
 
-func validateNamespaceFile(cmd *cobra.Command, fn string) (*namespace.Namespace, error) {
+func getSchema(cmd *cobra.Command) (*jsonschema.Schema, error) {
 	if configSchema == nil {
 		c := jsonschema.NewCompiler()
 		if err := c.AddResource(schemaPath, bytes.NewBuffer(config.Schema)); err != nil {
@@ -58,29 +76,121 @@ func validateNamespaceFile(cmd *cobra.Command, fn string) (*namespace.Namespace,
 			return nil, cmdx.FailSilently(cmd)
 		}
 	}
+	return configSchema, nil
+}
 
+func validateNamespaceFile(cmd *cobra.Command, fn string) (*namespace.Namespace, error) {
 	fc, err := ioutil.ReadFile(fn)
 	if err != nil {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Could not read file \"%s\": %+v\n", fn, err)
 		return nil, cmdx.FailSilently(cmd)
 	}
 
-	var val map[string]interface{}
-	if err := yaml.Unmarshal(fc, &val); err != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Encountered yaml unmarshal error for \"%s\": %+v\n", fn, err)
+	parse, err := config.GetParser(fn)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Unable to infer file type from \"%s\": %+v\n", fn, err)
 		return nil, cmdx.FailSilently(cmd)
 	}
 
-	if err := configSchema.ValidateInterface(val); err != nil {
+	return validateNamespaceBytes(cmd, fn, fc, parse)
+}
+
+func validateNamespaceBytes(cmd *cobra.Command, name string, b []byte, parser config.Parser) (*namespace.Namespace, error) {
+	schema, err := getSchema(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var val map[string]interface{}
+	if err := parser(b, &val); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Encountered unmarshal error for \"%s\": %+v\n", name, err)
+		return nil, cmdx.FailSilently(cmd)
+	}
+
+	if err := schema.ValidateInterface(val); err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "File %s was not a valid namespace file. Reasons:\n", name)
 		jsonschemax.FormatValidationErrorForCLI(cmd.ErrOrStderr(), config.Schema, err)
 		return nil, cmdx.FailSilently(cmd)
 	}
 
 	var n namespace.Namespace
-	if err := yaml.Unmarshal(fc, &n); err != nil {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Encountered yaml unmarshal error for \"%s\": %+v\n", fn, err)
+	if err := parser(b, &n); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Encountered unmarshal error for \"%s\": %+v\n", name, err)
 		return nil, cmdx.FailSilently(cmd)
 	}
 
 	return &n, nil
+}
+
+func validateConfigFile(cmd *cobra.Command, fn string) error {
+	fc, err := ioutil.ReadFile(fn)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Could not read file \"%s\": %+v\n", fn, err)
+		return cmdx.FailSilently(cmd)
+	}
+
+	parse, err := config.GetParser(fn)
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Unable to infer file type from \"%s\": %+v\n", fn, err)
+		return cmdx.FailSilently(cmd)
+	}
+
+	var val map[string]interface{}
+	if err := parse(fc, &val); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Encountered parse error for \"%s\": %+v\n", fn, err)
+		return cmdx.FailSilently(cmd)
+	}
+
+	if ns, ok := val["namespaces"]; ok {
+		// ns can either be a ws url or a list of namespace objects)
+		switch t := ns.(type) {
+		case string:
+			logger := logrusx.New("cmd", "0")
+			cw, err := config.NewNamespaceWatcher(cmd.Context(), logger, t)
+			if err != nil {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Encountered error reading config: %+v\n", err)
+				return cmdx.FailSilently(cmd)
+			}
+
+			files := cw.NamespaceFiles()
+			for _, file := range files {
+				_, err := validateNamespaceBytes(cmd, file.Name, file.Contents, file.Parser)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		case []interface{}:
+			for i, obj := range t {
+				fc, err := yaml.Marshal(obj)
+				if err != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Internal error. Failed to marshal yaml %+v\n", err)
+					return cmdx.FailSilently(cmd)
+				}
+				_, err = validateNamespaceBytes(cmd, fmt.Sprintf("index: %d", i), fc, yaml.Unmarshal)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		case []map[string]interface{}:
+			for i, obj := range t {
+				fc, err := yaml.Marshal(obj)
+				if err != nil {
+					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Internal error. Failed to marshal yaml %+v\n", err)
+					return cmdx.FailSilently(cmd)
+				}
+				_, err = validateNamespaceBytes(cmd, fmt.Sprintf("index: %d", i), fc, yaml.Unmarshal)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "unknown type %T for key 'namespaces' in config file: %v\n", t, t)
+			return cmdx.FailSilently(cmd)
+		}
+	} else {
+		return nil
+	}
 }

--- a/cmd/namespace/validate_test.go
+++ b/cmd/namespace/validate_test.go
@@ -1,0 +1,151 @@
+package namespace
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/ory/x/cmdx"
+	"github.com/ory/x/configx"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fileMode = 0644
+
+const (
+	configEmbeddedYaml = `
+dsn: memory
+namespaces:
+  - name: testns0
+    id: 0
+  - name: testns1
+    id: 1
+`
+
+	configEmbeddedJson = `{"dsn":"memory","namespaces":[{"name":"testns0","id":0}]}`
+
+	configEmbeddedToml = `
+[[namespaces]]
+name = "testns0"
+id = 0
+
+[[namespaces]]
+name = "testns1"
+id = 1
+`
+)
+
+const configReference = `
+dsn: memory
+namespaces: %s
+`
+
+const nsyaml = "name: testns0\nid: 0"
+const nsjson = `{"name": "testns1", "id": 1}`
+
+func TestValidateConfigNamespaces(t *testing.T) {
+	cmd := cmdx.CommandExecuter{New: validateCommand}
+
+	t.Run("case=read valid config with embedded namespaces", func(t *testing.T) {
+		dir := t.TempDir()
+		fnyaml := filepath.Join(dir, "keto.yaml")
+		require.NoError(t, ioutil.WriteFile(fnyaml, []byte(configEmbeddedYaml), fileMode))
+
+		fnjson := filepath.Join(dir, "keto.json")
+		require.NoError(t, ioutil.WriteFile(fnjson, []byte(configEmbeddedJson), fileMode))
+
+		fntoml := filepath.Join(dir, "keto.toml")
+		require.NoError(t, ioutil.WriteFile(fntoml, []byte(configEmbeddedToml), fileMode))
+
+		stdOut := cmd.ExecNoErr(t, "validate", "-c", fnyaml+","+fnjson+","+fntoml)
+		assert.Equal(t, "Congrats, all files are valid!\n", stdOut)
+	})
+
+	t.Run("case=supports 3 namespace file formats", func(t *testing.T) {
+		dir := t.TempDir()
+		nsfiles := map[string]string{
+			filepath.Join(dir, "ns.yaml"): "name: testns0\nid: 0",
+			filepath.Join(dir, "ns.json"): "{\"name\": \"testns0\",\"id\": 0}",
+			filepath.Join(dir, "ns.toml"): "name = \"testns0\"\nid = 0",
+		}
+		for fn, contents := range nsfiles {
+			require.NoError(t, ioutil.WriteFile(fn, []byte(contents), fileMode))
+		}
+
+		params := append([]string{"validate"}, keys(nsfiles)...)
+		cmd.ExecNoErr(t, params...)
+	})
+
+	t.Run("case=unknown namespace format gives error", func(t *testing.T) {
+		fn := filepath.Join(t.TempDir(), "ns.txt")
+		require.NoError(t, ioutil.WriteFile(fn, []byte("name: ns\nid: 0"), fileMode))
+
+		stdOut := cmd.ExecExpectedErr(t, "validate", fn)
+		assert.Contains(t, stdOut, "Unable to infer file type")
+	})
+
+	t.Run("case=config passed as varg fails", func(t *testing.T) {
+		fn := filepath.Join(t.TempDir(), "keto.yaml")
+		require.NoError(t, ioutil.WriteFile(fn, []byte(configEmbeddedYaml), fileMode))
+
+		// interprets config file as namespace file when `-c` flag is not passed
+		stdOut := cmd.ExecExpectedErr(t, "validate", fn)
+		assert.Regexp(t, "additionalProperties ((\"namespaces\", \"dsn\")|(\"dsn\", \"namespaces\")) not allowed", stdOut)
+	})
+
+	t.Run("case=read config with invalid embedded namespace", func(t *testing.T) {
+		fn := filepath.Join(t.TempDir(), "keto.yaml")
+		require.NoError(t, ioutil.WriteFile(fn, []byte(`{"namespaces":[{"id":"x","name":"x"}]}`), fileMode))
+
+		stdOut := cmd.ExecExpectedErr(t, "validate", "--config", fn)
+		assert.Contains(t, stdOut, "not a valid namespace file")
+		assert.Contains(t, stdOut, "id:")
+	})
+
+	t.Run("case=read config with namespace as dir reference", func(t *testing.T) {
+		nsdir := t.TempDir()
+		fn := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, ioutil.WriteFile(filepath.Join(nsdir, "ns0.yaml"), []byte(nsyaml), fileMode))
+		require.NoError(t, ioutil.WriteFile(filepath.Join(nsdir, "ns1.json"), []byte(nsjson), fileMode))
+		require.NoError(t, ioutil.WriteFile(fn, []byte(fmt.Sprintf(configReference, nsdir)), fileMode))
+
+		cmd.PersistentArgs = []string{}
+		stdOut := cmd.ExecNoErr(t, "validate", "-c", fn)
+		assert.Equal(t, "Congrats, all files are valid!\n", stdOut)
+
+		stdOut = cmd.ExecNoErr(t, "validate", "-c", fmt.Sprintf("%s,%s", fn, fn))
+		assert.Equal(t, "Congrats, all files are valid!\n", stdOut)
+	})
+
+	t.Run("case=read config with dir reference bad namespaces", func(t *testing.T) {
+		nsdir := t.TempDir()
+		fn := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, ioutil.WriteFile(filepath.Join(nsdir, "ns0.yaml"), []byte("name: badId\nid: foo"), fileMode))
+		require.NoError(t, ioutil.WriteFile(fn, []byte(fmt.Sprintf(configReference, nsdir)), fileMode))
+
+		cmd.PersistentArgs = []string{}
+		stdOut := cmd.ExecExpectedErr(t, "validate", "-c", fn)
+		assert.Contains(t, stdOut, "contains values or keys which are invalid")
+	})
+}
+
+func validateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keto",
+		Short: "Global and consistent permission and authorization server",
+	}
+	configx.RegisterConfigFlag(cmd.PersistentFlags(), []string{})
+	cmd.AddCommand(NewValidateCmd())
+	return cmd
+}
+
+func keys(m map[string]string) []string {
+	rv := make([]string, 0, len(m))
+	for k := range m {
+		rv = append(rv, k)
+	}
+	return rv
+}

--- a/internal/driver/config/namespace_watcher.go
+++ b/internal/driver/config/namespace_watcher.go
@@ -22,12 +22,23 @@ import (
 )
 
 type (
+	Parser func([]byte, interface{}) error
+
+	NamespaceFile struct {
+		Name     string
+		Contents []byte
+		Parser   Parser
+
+		namespace *namespace.Namespace // last successfully parsed namespace. May be nil if there was a parse error
+	}
+
 	NamespaceWatcher struct {
 		sync.RWMutex
-		namespaces map[string]*namespace.Namespace
+		namespaces map[string]*NamespaceFile
 		ec         watcherx.EventChannel
 		l          *logrusx.Logger
 		target     string
+		w          watcherx.Watcher
 	}
 )
 
@@ -43,10 +54,8 @@ func NewNamespaceWatcher(ctx context.Context, l *logrusx.Logger, target string) 
 		ec:         make(watcherx.EventChannel),
 		l:          l,
 		target:     target,
-		namespaces: make(map[string]*namespace.Namespace),
+		namespaces: make(map[string]*NamespaceFile),
 	}
-
-	var w watcherx.Watcher
 
 	info, err := os.Stat(u.Path)
 	if err != nil {
@@ -54,9 +63,9 @@ func NewNamespaceWatcher(ctx context.Context, l *logrusx.Logger, target string) 
 	}
 
 	if info.IsDir() {
-		w, err = watcherx.WatchDirectory(ctx, u.Path, nw.ec)
+		nw.w, err = watcherx.WatchDirectory(ctx, u.Path, nw.ec)
 	} else {
-		w, err = watcherx.Watch(ctx, u, nw.ec)
+		nw.w, err = watcherx.Watch(ctx, u, nw.ec)
 	}
 	// this handles the watcher init error
 	if err != nil {
@@ -64,7 +73,7 @@ func NewNamespaceWatcher(ctx context.Context, l *logrusx.Logger, target string) 
 	}
 
 	// trigger initial load
-	done, err := w.DispatchNow()
+	done, err := nw.w.DispatchNow()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -105,12 +114,19 @@ func eventHandler(ctx context.Context, nw *NamespaceWatcher, done <-chan int, in
 					nw.Lock()
 					defer nw.Unlock()
 
-					n := parseNamespace(nw.l, e.Reader(), e.Source())
+					n := readNamespaceFile(nw.l, e.Reader(), e.Source())
 					if n == nil {
 						return
+					} else if n.namespace == nil {
+						// parse failed, rolling back to previous working version
+						if existing, ok := nw.namespaces[e.Source()]; ok {
+							existing.Contents = n.Contents
+						} else {
+							nw.namespaces[e.Source()] = n
+						}
+					} else {
+						nw.namespaces[e.Source()] = n
 					}
-
-					nw.namespaces[e.Source()] = n
 				}()
 			case *watcherx.ErrorEvent:
 				nw.l.WithError(etyped).Errorf("Received error while watching namespace files at target %s.", nw.target)
@@ -119,19 +135,11 @@ func eventHandler(ctx context.Context, nw *NamespaceWatcher, done <-chan int, in
 	}
 }
 
-func parseNamespace(l *logrusx.Logger, r io.Reader, source string) *namespace.Namespace {
-	var parser func([]byte, interface{}) error
-
-	knownFormats := stringsx.RegisteredCases{}
-	switch ext := filepath.Ext(source); ext {
-	case knownFormats.AddCase(".yaml"), knownFormats.AddCase(".yml"):
-		parser = yaml.Unmarshal
-	case knownFormats.AddCase(".json"):
-		parser = json.Unmarshal
-	case knownFormats.AddCase(".toml"):
-		parser = toml.Unmarshal
-	default:
-		l.WithError(knownFormats.ToUnknownCaseErr(ext)).WithField("file_name", source).Warn("could not infer format from file extension")
+func readNamespaceFile(l *logrusx.Logger, r io.Reader, source string) *NamespaceFile {
+	var parse Parser
+	parse, err := GetParser(source)
+	if err != nil {
+		l.WithError(err).WithField("file_name", source).Warn("could not infer format from file extension")
 		return nil
 	}
 
@@ -142,21 +150,21 @@ func parseNamespace(l *logrusx.Logger, r io.Reader, source string) *namespace.Na
 	}
 
 	n := namespace.Namespace{}
-	if err := parser(raw, &n); err != nil {
+	if err := parse(raw, &n); err != nil {
 		l.WithError(errors.WithStack(err)).WithField("file_name", source).Error("could not parse namespace file")
-		return nil
+		return &NamespaceFile{Name: source, Contents: raw, Parser: parse}
 	}
 
-	return &n
+	return &NamespaceFile{Name: source, Contents: raw, Parser: parse, namespace: &n}
 }
 
 func (n *NamespaceWatcher) GetNamespace(_ context.Context, name string) (*namespace.Namespace, error) {
 	n.RLock()
 	defer n.RUnlock()
 
-	for _, nspace := range n.namespaces {
-		if nspace.Name == name {
-			return nspace, nil
+	for _, nsf := range n.namespaces {
+		if nsf.namespace != nil && nsf.namespace.Name == name {
+			return nsf.namespace, nil
 		}
 	}
 
@@ -168,9 +176,35 @@ func (n *NamespaceWatcher) Namespaces(_ context.Context) ([]*namespace.Namespace
 	defer n.RUnlock()
 
 	nspaces := make([]*namespace.Namespace, 0, len(n.namespaces))
-	for _, nspace := range n.namespaces {
-		nspaces = append(nspaces, nspace)
+	for _, nsf := range n.namespaces {
+		if nsf.namespace != nil {
+			nspaces = append(nspaces, nsf.namespace)
+		}
 	}
-
 	return nspaces, nil
+}
+
+func (n *NamespaceWatcher) NamespaceFiles() []*NamespaceFile {
+	n.RLock()
+	defer n.RUnlock()
+
+	nsfs := make([]*NamespaceFile, 0, len(n.namespaces))
+	for _, nsf := range n.namespaces {
+		nsfs = append(nsfs, nsf)
+	}
+	return nsfs
+}
+
+func GetParser(fn string) (Parser, error) {
+	knownFormats := stringsx.RegisteredCases{}
+	switch ext := filepath.Ext(fn); ext {
+	case knownFormats.AddCase(".yaml"), knownFormats.AddCase(".yml"):
+		return yaml.Unmarshal, nil
+	case knownFormats.AddCase(".json"):
+		return json.Unmarshal, nil
+	case knownFormats.AddCase(".toml"):
+		return toml.Unmarshal, nil
+	default:
+		return nil, knownFormats.ToUnknownCaseErr(ext)
+	}
 }


### PR DESCRIPTION
## Related issue

#586 

cc @zepatrik 

## Proposed changes

Adds support for parsing configuration files containing either a list of namespace objects or a reference to a location with namespace objects.

It extends the existing functionality. Here's example usage.

```
### VALID
./keto namespace validate -c config.yaml config2.yaml

./keto namespace validate namespace.yaml ns2.yaml

# namespaces and configs are all validated
./keto namespace validate namespace.yaml ns2.yaml -c config.yaml

### INVALID

# interprets config.yaml as a namespace file
./keto namespace validate config.yaml
```

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

I changed the way the namespace watcher works. This is because I wanted to reuse the code in watcher which determines the correct parser type and does an initial scrape of the target location. To make it possible to reuse watcher for validation, I had to leave the original source file contents inside the scraped file.
