### PR TITLE
docs : Update npm links due to organization move

### DIFF
--- a/docs/docs/sdk/index.md
+++ b/docs/docs/sdk/index.md
@@ -28,9 +28,9 @@ repositories:
 - [Python](https://pypi.org/project/ory-keto-client/)
 - [Ruby](https://rubygems.org/gems/ory-keto-client)
 - [Rust](https://crates.io/crates/ory-keto-client)
-- [NodeJS REST](https://www.npmjs.com/package/@oryd/keto-client) (with
+- [NodeJS REST](https://www.npmjs.com/package/@ory/keto-client) (with
   TypeScript)
-- [NodeJS gRPC](https://www.npmjs.com/package/@oryd/keto-grpc-client) (with
+- [NodeJS gRPC](https://www.npmjs.com/package/@ory/keto-grpc-client) (with
   TypeScript)
 
 Take a look at the source:


### PR DESCRIPTION
I just noticed that the links for the npm clients are outdated due the the organization move.

> ORY moved its NPM organization from @oryd to @ory. Please use @ory/keto-client instead. Packages in @oryd will not be updated any more.

## Related issue

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
