### PR TITLE
fix(cli): panic when printing nil expand trees

### DIFF
--- a/cmd/expand/root.go
+++ b/cmd/expand/root.go
@@ -61,7 +61,7 @@ func NewExpandCmd() *cobra.Command {
 			switch flagx.MustGetString(cmd, cmdx.FlagFormat) {
 			case string(cmdx.FormatDefault), "":
 				if tree == nil && !flagx.MustGetBool(cmd, cmdx.FlagQuiet) {
-					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Got an empty tree. This probably means that the requested relation tuple is not present in Keto.")
+					_, _ = fmt.Fprint(cmd.OutOrStdout(), "Got an empty tree. This probably means that the requested relation tuple is not present in Keto.")
 				}
 				_, _ = fmt.Fprintln(cmd.OutOrStdout())
 			}

--- a/cmd/expand/root.go
+++ b/cmd/expand/root.go
@@ -60,6 +60,9 @@ func NewExpandCmd() *cobra.Command {
 			cmdx.PrintJSONAble(cmd, tree)
 			switch flagx.MustGetString(cmd, cmdx.FlagFormat) {
 			case string(cmdx.FormatDefault), "":
+				if tree == nil && !flagx.MustGetBool(cmd, cmdx.FlagQuiet) {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Got an empty tree. This probably means that the requested relation tuple is not present in Keto.")
+				}
 				_, _ = fmt.Fprintln(cmd.OutOrStdout())
 			}
 			return nil
@@ -68,6 +71,7 @@ func NewExpandCmd() *cobra.Command {
 
 	client.RegisterRemoteURLFlags(cmd.Flags())
 	cmdx.RegisterJSONFormatFlags(cmd.Flags())
+	cmdx.RegisterNoiseFlags(cmd.Flags())
 	cmd.Flags().Int32P(FlagMaxDepth, "d", 100, "maximum depth of the tree")
 
 	return cmd

--- a/cmd/expand/root_test.go
+++ b/cmd/expand/root_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ory/x/cmdx"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ory/keto/cmd/client"
@@ -15,7 +16,15 @@ func TestExpandCommand(t *testing.T) {
 	ts := client.NewTestServer(t, client.ReadServer, []*namespace.Namespace{nspace}, NewExpandCmd)
 	defer ts.Shutdown(t)
 
-	ts.Cmd.PersistentArgs = append(ts.Cmd.PersistentArgs, "--"+cmdx.FlagFormat, string(cmdx.FormatJSON))
-	stdOut := ts.Cmd.ExecNoErr(t, "access", nspace.Name, "object")
-	assert.Equal(t, "null\n", stdOut)
+	t.Run("case=unknown tuple", func(t *testing.T) {
+		t.Run("format=JSON", func(t *testing.T) {
+			stdOut := ts.Cmd.ExecNoErr(t, "access", nspace.Name, "object", "--"+cmdx.FlagFormat, string(cmdx.FormatJSON))
+			assert.Equal(t, "null\n", stdOut)
+		})
+
+		t.Run("format=default", func(t *testing.T) {
+			stdOut := ts.Cmd.ExecNoErr(t, "access", nspace.Name, "object", "--"+cmdx.FlagFormat, string(cmdx.FormatDefault))
+			assert.Contains(t, stdOut, "empty tree")
+		})
+	})
 }

--- a/contrib/docs-code-samples/expand-api-display-access/99-cleanup/main.go
+++ b/contrib/docs-code-samples/expand-api-display-access/99-cleanup/main.go
@@ -1,3 +1,4 @@
+//go:build docscodesamples
 // +build docscodesamples
 
 package main

--- a/contrib/docs-code-samples/list-api-display-objects/99-cleanup/main.go
+++ b/contrib/docs-code-samples/list-api-display-objects/99-cleanup/main.go
@@ -1,3 +1,4 @@
+//go:build docscodesamples
 // +build docscodesamples
 
 package main

--- a/contrib/docs-code-samples/simple-access-check-guide/99-cleanup/main.go
+++ b/contrib/docs-code-samples/simple-access-check-guide/99-cleanup/main.go
@@ -1,3 +1,4 @@
+//go:build docscodesamples
 // +build docscodesamples
 
 package main

--- a/docs/docs/cli/keto-expand.md
+++ b/docs/docs/cli/keto-expand.md
@@ -28,6 +28,7 @@ keto expand &lt;relation&gt; &lt;namespace&gt; &lt;object&gt; [flags]
   -f, --format string         Set the output format. One of default, json, and json-pretty. (default &#34;default&#34;)
   -h, --help                  help for expand
   -d, --max-depth int32       maximum depth of the tree (default 100)
+  -q, --quiet                 Be quiet with output printing.
       --read-remote string    Remote URL of the read API endpoint. (default &#34;127.0.0.1:4466&#34;)
       --write-remote string   Remote URL of the write API endpoint. (default &#34;127.0.0.1:4467&#34;)
 ```

--- a/go_mod_indirect_pins.go
+++ b/go_mod_indirect_pins.go
@@ -1,3 +1,4 @@
+//go:build go_mod_indirect_pins
 // +build go_mod_indirect_pins
 
 package main

--- a/internal/expand/tree.go
+++ b/internal/expand/tree.go
@@ -162,6 +162,10 @@ func TreeFromProto(t *acl.SubjectTree) (*Tree, error) {
 }
 
 func (t *Tree) String() string {
+	if t == nil {
+		return ""
+	}
+
 	sub := t.Subject.String()
 
 	if t.Type == Leaf {


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

closes #553 
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
