### PR TITLE
fix: `make sdk` dependecy on the Ory CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ docker:
 
 # Generates the SDKs
 .PHONY: sdk
-sdk: .bin/swagger .bin/cli
+sdk: .bin/swagger .bin/ory
 		swagger generate spec -m -o ./spec/api.json -x internal/httpclient -x proto/ory/keto -x docker
-		cli dev swagger sanitize ./spec/api.json
+		ory dev swagger sanitize ./spec/api.json
 		swagger flatten --with-flatten=remove-unused -o ./spec/api.json ./spec/api.json
 		swagger validate ./spec/api.json
 		rm -rf internal/httpclient


### PR DESCRIPTION


<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

The dependency changed from `.bin/cli` to `.bin/ory`, which was not updated in the `make sdk` dependency list. That prevented the docs build CI job from succeeding, e.g. https://app.circleci.com/pipelines/github/ory/keto/1415/workflows/6ea6379d-10ce-403c-b4e4-478a0548a031/jobs/9237
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->
