### PR TITLE
ci: add GH workflow to release the go gRPC client

### DIFF
--- a/.github/workflows/release-go-grpc-client.yml
+++ b/.github/workflows/release-go-grpc-client.yml
@@ -27,6 +27,8 @@ jobs:
         run: cd proto; cd proto; go test ./...
       - name: Create git tag
         run: |
+          git config --local user.email "zepatrik@users.noreply.github.com"
+          git config --local user.name "zepatrik"
           git tag -a "proto/$RELEASE_VERSION" -m "Release $RELEASE_VERSION of the go gRPC Client. See CHANGELOG.md for more info."
           git push origin "proto/$RELEASE_VERSION"
         env:

--- a/.github/workflows/release-go-grpc-client.yml
+++ b/.github/workflows/release-go-grpc-client.yml
@@ -1,0 +1,33 @@
+name: Release the go gRPC client as `proto/$VERSION`
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to release. Should be a patch of the latest Keto release.
+        required: true
+  release:
+    types:
+      - created
+
+jobs:
+  tag:
+    #   this is set on dispatch        this should prevent the action from triggering itself
+    if: github.event.inputs.version || !startsWith('proto/', github.ref)
+    runs-on: ubuntu-latest
+    name: Publish
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - name: Download dependencies
+        run: cd proto; go mod tidy
+      - name: Test
+        run: cd proto; cd proto; go test ./...
+      - name: Create git tag
+        run: |
+          git tag -a "proto/$RELEASE_VERSION" -m "Release $RELEASE_VERSION of the go gRPC Client. See CHANGELOG.md for more info."
+          git push origin "proto/$RELEASE_VERSION"
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref }}

--- a/docs/docs/sdk/index.md
+++ b/docs/docs/sdk/index.md
@@ -21,8 +21,9 @@ repositories:
 
 - [Dart](https://pub.dev/packages/ory_keto_client)
 - [.NET](https://www.nuget.org/packages/Ory.Keto.Client/)
+- [Go gRPC](https://github.com/ory/keto/blob/master/proto/go.mod) (import using
+  `go get github.com/ory/keto/proto`)
 - [Go REST](https://github.com/ory/keto-client-go)
-- [Go gRPC](https://github.com/ory/keto/blob/master/proto/ory/keto/acl)
 - [Java](https://search.maven.org/artifact/sh.ory.keto/keto-client)
 - [PHP](https://packagist.org/packages/ory/keto-client)
 - [Python](https://pypi.org/project/ory-keto-client/)


### PR DESCRIPTION
This adds a workflow to release hierarchical tags for the go gRPC client. It runs on every release of Keto, but can also be released manually to provide patches.

See https://golang.org/doc/modules/managing-source#multiple-module-source for more details on how hierarchical tags work in case you don't know them in-depth.

Closes #635