### PR TITLE
fix: exclude `/health` endpoints from logs

### DIFF
--- a/internal/driver/registry_default.go
+++ b/internal/driver/registry_default.go
@@ -322,7 +322,7 @@ func (r *RegistryDefault) allHandlers() []Handler {
 }
 
 func (r *RegistryDefault) ReadRouter() http.Handler {
-	n := negroni.New(reqlog.NewMiddlewareFromLogger(r.l, "write#Ory Keto"))
+	n := negroni.New(reqlog.NewMiddlewareFromLogger(r.l, "write#Ory Keto").ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath))
 
 	br := &x.ReadRouter{Router: httprouter.New()}
 
@@ -347,7 +347,7 @@ func (r *RegistryDefault) ReadRouter() http.Handler {
 }
 
 func (r *RegistryDefault) WriteRouter() http.Handler {
-	n := negroni.New(reqlog.NewMiddlewareFromLogger(r.l, "write#Ory Keto"))
+	n := negroni.New(reqlog.NewMiddlewareFromLogger(r.l, "write#Ory Keto").ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath))
 
 	pr := &x.WriteRouter{Router: httprouter.New()}
 

--- a/internal/driver/registry_default.go
+++ b/internal/driver/registry_default.go
@@ -322,7 +322,7 @@ func (r *RegistryDefault) allHandlers() []Handler {
 }
 
 func (r *RegistryDefault) ReadRouter() http.Handler {
-	n := negroni.New(reqlog.NewMiddlewareFromLogger(r.l, "write#Ory Keto").ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath))
+	n := negroni.New(reqlog.NewMiddlewareFromLogger(r.l, "read#Ory Keto").ExcludePaths(healthx.AliveCheckPath, healthx.ReadyCheckPath))
 
 	br := &x.ReadRouter{Router: httprouter.New()}
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

closes #594 

Kratos does not seem to make this configurable, so I guess it is fine to just always exclude them: https://github.com/ory/kratos/blob/75408a0bc07914e588985134da1e2ded7de984b1/cmd/daemon/middleware.go#L17
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->
