### PR TITLE
docs: change npm org scope from @oryd to @ory

### DIFF
--- a/docs/versioned_docs/version-v0.6/sdk/index.md
+++ b/docs/versioned_docs/version-v0.6/sdk/index.md
@@ -28,9 +28,9 @@ repositories:
 - [Python](https://pypi.org/project/ory-keto-client/)
 - [Ruby](https://rubygems.org/gems/ory-keto-client)
 - [Rust](https://crates.io/crates/ory-keto-client)
-- [NodeJS REST](https://www.npmjs.com/package/@oryd/keto-client) (with
+- [NodeJS REST](https://www.npmjs.com/package/@ory/keto-client) (with
   TypeScript)
-- [NodeJS gRPC](https://www.npmjs.com/package/@oryd/keto-grpc-client) (with
+- [NodeJS gRPC](https://www.npmjs.com/package/@ory/keto-grpc-client) (with
   TypeScript)
 
 Take a look at the source:


### PR DESCRIPTION
https://www.npmjs.com/package/@oryd/keto-client has a notice that @oryd has changed to @ory, and https://www.npmjs.com/package/@oryd/keto-grpc-client simply doesn't exist (whereas the @ory version does)
