### PR TITLE
ci: add arm64 to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
       - CXX=o64-clang++
     goarch:
       - amd64
+      - arm64
     goos:
       - darwin
 


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

closes #741 

I think it should be fine for the non-sqlite build already, as that has the combination of `darwin` and `arm64`, but the `keto-sqlite-darwin`, which is included in brew, was lacking the M1 definition. 
