### PR TITLE
Remove "and only" from open-source Zanzibar line

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     <a href="#backers" alt="sponsors on Open Collective"><img src="https://opencollective.com/ory/backers/badge.svg" /></a> <a href="#sponsors" alt="Sponsors on Open Collective"><img src="https://opencollective.com/ory/sponsors/badge.svg" /></a>
     <a href="https://github.com/ory/keto/blob/master/CODE_OF_CONDUCT.md" alt="Ory Code of Conduct"><img src="https://img.shields.io/badge/ory-code%20of%20conduct-green" /></a>
 </p>
-Ory Keto is the first and only open source implementation of "Zanzibar: Google's
+Ory Keto is the first open source implementation of "Zanzibar: Google's
 Consistent, Global Authorization System":
 
 > Determining whether online users are authorized to access digital objects is


### PR DESCRIPTION
[Authzed's SpiceDB](https://github.com/authzed/spicedb) has just been open-sourced as well: it may be even worth mentioning in the README.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.