### PR TITLE
ci: strip `refs/tags/` of go-gRPC client tags

### DIFF
--- a/.github/workflows/release-go-grpc-client.yml
+++ b/.github/workflows/release-go-grpc-client.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           git config --local user.email "zepatrik@users.noreply.github.com"
           git config --local user.name "zepatrik"
-          RELEASE_VERSION="sed 's#^refs/tags/##' <(echo $RELEASE_REF)"
+          RELEASE_VERSION="$(sed 's#^refs/tags/##' <(echo $RELEASE_REF))"
           git tag -a "proto/$RELEASE_VERSION" -m "Release $RELEASE_VERSION of the go gRPC Client. See CHANGELOG.md for more info."
           git push origin "proto/$RELEASE_VERSION"
         env:

--- a/.github/workflows/release-go-grpc-client.yml
+++ b/.github/workflows/release-go-grpc-client.yml
@@ -29,7 +29,8 @@ jobs:
         run: |
           git config --local user.email "zepatrik@users.noreply.github.com"
           git config --local user.name "zepatrik"
+          RELEASE_VERSION="sed 's#^refs/tags/##' <(echo $RELEASE_REF)"
           git tag -a "proto/$RELEASE_VERSION" -m "Release $RELEASE_VERSION of the go gRPC Client. See CHANGELOG.md for more info."
           git push origin "proto/$RELEASE_VERSION"
         env:
-          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref }}
+          RELEASE_REF: ${{ github.event.inputs.version || github.ref }}

--- a/cmd/migrate/up.go
+++ b/cmd/migrate/up.go
@@ -23,7 +23,7 @@ func newUpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "up",
 		Short: "Migrate the database up",
-		Long: `Run this command on a fresh SQL installation and when you upgrade Ory Keto from version v0.7.0 and later.
+		Long: `Run this command on a fresh SQL installation and when you upgrade Ory Keto from version v0.7.x and later.
 
 It is recommended to run this command close to the SQL instance (e.g. same subnet) instead of over the public internet.
 This decreases risk of failure and decreases time required.

--- a/docs/docs/cli/keto-migrate-up.md
+++ b/docs/docs/cli/keto-migrate-up.md
@@ -17,7 +17,7 @@ Migrate the database up
 ### Synopsis
 
 Run this command on a fresh SQL installation and when you upgrade Ory Keto from
-version v0.7.0-alpha.0.pre.5 and later.
+version v0.7.0 and later.
 
 It is recommended to run this command close to the SQL instance (e.g. same
 subnet) instead of over the public internet. This decreases risk of failure and

--- a/docs/docs/cli/keto-migrate-up.md
+++ b/docs/docs/cli/keto-migrate-up.md
@@ -17,7 +17,7 @@ Migrate the database up
 ### Synopsis
 
 Run this command on a fresh SQL installation and when you upgrade Ory Keto from
-version v0.7.0 and later.
+version v0.7.x and later.
 
 It is recommended to run this command close to the SQL instance (e.g. same
 subnet) instead of over the public internet. This decreases risk of failure and


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related issue(s)

![Screenshot from 2021-10-05 14-05-39](https://user-images.githubusercontent.com/5354445/136019113-2bae481d-0759-4141-bd5b-48c3073ca2a0.png)

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

The fix works as tested manually:
```sh
$ sed 's#^refs/tags/##' <(echo refs/tags/v0.7.0-alpha.0.pre.5)
v0.7.0-alpha.0.pre.5
$ sed 's#^refs/tags/##' <(echo v0.7.0-alpha.0.pre.5)
v0.7.0-alpha.0.pre.5
```