### PR TITLE
chore: update repository template to f4135705

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ that your company deserves a spot here, reach out to
             <td align="center"><img height="32px" src="https://raw.githubusercontent.com/ory/meta/master/static/adopters/sainsburys.svg" alt="Sainsbury's"></td>
             <td><a href="https://www.sainsburys.co.uk/">sainsburys.co.uk</a></td>
         </tr>
-                <tr>
+        <tr>
             <td>Adopter *</td>
             <td>Contraste</td>
             <td align="center"><img height="32px" src="https://raw.githubusercontent.com/ory/meta/master/static/adopters/contraste.svg" alt="Contraste"></td>
@@ -211,7 +211,7 @@ that your company deserves a spot here, reach out to
 
 We also want to thank all individual contributors
 
-<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&button=false" /></a>
+<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&limit=714&button=false" /></a>
 
 as well as all of our backers
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -184,7 +184,7 @@ Pull requests eligible for review
 5. have signed our
    [Contributor License Agreement](https://cla-assistant.io/ory/keto);
 6. include a proper git commit message following the
-   [Conventional Commit Specification](https://www.conventionalcommits.org/en/v0.7.0-alpha.1/).
+   [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
 
 If all of these items are checked, the pull request is ready to be reviewed and
 you should change the status to "Ready for review" and


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/f413570526ef9d1a0592df89bd5f6521a5c09030.