### PR TITLE
chore: update repository template to 6989295f

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ that your company deserves a spot here, reach out to
             <td align="center"><img height="32px" src="https://raw.githubusercontent.com/ory/meta/master/static/adopters/sainsburys.svg" alt="Sainsbury's"></td>
             <td><a href="https://www.sainsburys.co.uk/">sainsburys.co.uk</a></td>
         </tr>
-                <tr>
+        <tr>
             <td>Adopter *</td>
             <td>Contraste</td>
             <td align="center"><img height="32px" src="https://raw.githubusercontent.com/ory/meta/master/static/adopters/contraste.svg" alt="Contraste"></td>
@@ -211,7 +211,7 @@ that your company deserves a spot here, reach out to
 
 We also want to thank all individual contributors
 
-<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&button=false" /></a>
+<a href="https://opencollective.com/ory" target="_blank"><img src="https://opencollective.com/ory/contributors.svg?width=890&limit=714&button=false" /></a>
 
 as well as all of our backers
 
@@ -243,7 +243,7 @@ design:
 - Scales without effort
 - Minimize room for human and network errors
 
-Ory's architecture designed to run best on a Container Orchestration Systems
+Ory's architecture is designed to run best on a Container Orchestration system
 such as Kubernetes, CloudFoundry, OpenShift, and similar projects. Binaries are
 small (5-15MB) and available for all popular processor types (ARM, AMD64, i386)
 and operating systems (FreeBSD, Linux, macOS, Windows) without system
@@ -256,7 +256,7 @@ Management system that is built according to
 [cloud architecture best practices](https://www.ory.sh/docs/next/ecosystem/software-architecture-philosophy).
 It implements core use cases that almost every software application needs to
 deal with: Self-service Login and Registration, Multi-Factor Authentication
-(MFA/2FA), Account Recovery and Verification, Profile and Account Management.
+(MFA/2FA), Account Recovery and Verification, Profile, and Account Management.
 
 ### Ory Hydra: OAuth2 & OpenID Connect Server
 

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -184,7 +184,7 @@ Pull requests eligible for review
 5. have signed our
    [Contributor License Agreement](https://cla-assistant.io/ory/keto);
 6. include a proper git commit message following the
-   [Conventional Commit Specification](https://www.conventionalcommits.org/en/v0.7.0-alpha.1/).
+   [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
 
 If all of these items are checked, the pull request is ready to be reviewed and
 you should change the status to "Ready for review" and


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/6989295f43aa448ef3131766fd13eaaac2905f1d.