### PR TITLE
fix: docker compose migrate not working (#773)

### DIFF
--- a/config/keto.yml
+++ b/config/keto.yml
@@ -1,0 +1,12 @@
+version: v0.7.0-alpha.1
+
+log:
+  level: debug
+
+serve:
+  read:
+    host: 0.0.0.0
+    port: 4466
+  write:
+    host: 0.0.0.0
+    port: 4467

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -1,25 +1,36 @@
-version: '3'
+version: '3.2'
 
 services:
 
   keto-migrate:
-    image: oryd/keto:v0.6.0-alpha.1
+    image: oryd/keto:v0.7.0-alpha.1
     links:
-      - postgresd:postgresd
+      - mysqld:mysqld
+    volumes:
+      - type: bind
+        source: ./config
+        target: /home/ory
     environment:
       - LOG_LEVEL=debug
-      - DSN=mysql://root:secret@tcp(mysqld:3306)/mysql&max_conns=20&max_idle_conns=4
+      - DSN=mysql://root:secret@mysqld:3306/mysql&max_conns=20&max_idle_conns=4
     command: ["migrate", "up", "-y"]
     restart: on-failure
 
   keto:
-    image: oryd/keto:v0.6.0-alpha.1
+    image: oryd/keto:v0.7.0-alpha.1
     links:
-      - postgresd:postgresd
+      - mysqld:mysqld
+    volumes:
+      - type: bind
+        source: ./config
+        target: /home/ory
+    ports:
+      - '4466:4466'
+      - '4467:4467'
     depends_on:
       - keto-migrate
     environment:
-      - DSN=mysql://root:secret@tcp(mysqld:3306)/mysql&max_conns=20&max_idle_conns=4
+      - DSN=mysql://root:secret@mysqld:3306/mysql&max_conns=20&max_idle_conns=4
 
   mysqld:
     image: mysql:5.7

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -9,8 +9,7 @@ services:
     environment:
       - LOG_LEVEL=debug
       - DSN=mysql://root:secret@tcp(mysqld:3306)/mysql&max_conns=20&max_idle_conns=4
-    command:
-      migrate sql -e
+    command: ["migrate", "up", "-y"]
     restart: on-failure
 
   keto:

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -13,8 +13,7 @@ services:
     environment:
       - LOG_LEVEL=debug
       - DSN=postgres://dbuser:secret@postgresd:5432/accesscontroldb?sslmode=disable
-    command:
-      migrate sql postgres://dbuser:secret@postgresd:5432/accesscontroldb?sslmode=disable
+    command: ["migrate", "up", "-y"]
     restart: on-failure
 
   keto:

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -3,12 +3,12 @@ version: '3.2'
 services:
 
   keto-migrate:
-    image: oryd/keto:v0.7.0-alpha.0
+    image: oryd/keto:v0.7.0-alpha.1
     links:
       - postgresd:postgresd
     volumes:
       - type: bind
-        source: .
+        source: ./config
         target: /home/ory
     environment:
       - LOG_LEVEL=debug
@@ -17,13 +17,21 @@ services:
     restart: on-failure
 
   keto:
-    image: oryd/keto:v0.7.0-alpha.0
+    image: oryd/keto:v0.7.0-alpha.1
     links:
       - postgresd:postgresd
+    volumes:
+      - type: bind
+        source: ./config
+        target: /home/ory
+    ports:
+      - '4466:4466'
+      - '4467:4467'
     depends_on:
       - keto-migrate
     environment:
       - DSN=postgres://dbuser:secret@postgresd:5432/accesscontroldb?sslmode=disable
+    restart: on-failure
 
   postgresd:
     image: postgres:9.6


### PR DESCRIPTION
This Pull request closes #773

The issue is related to the ENTRYPONT and the CMD within the Dockerfile, both are using the exec format `["keto"]` and `["serve"]`. That forces the usage of exec form instead of the bash form into the docker-compose commands `["migrate", "up", "-y"]`

In addition to that, a new config folder with a default `keto.yml` file has been added to the repository so as to be able to test the docker-compose.

Use `docker-compose -f docker-compose-postgres.yml up` to test PostgreSQL.

MySQL docker-compose has been tested and not working yet.