### PR TITLE
feat(backend): adding a read api to get count of relation tuples

### DIFF
--- a/internal/persistence/sql/relationtuples.go
+++ b/internal/persistence/sql/relationtuples.go
@@ -276,6 +276,24 @@ func (p *Persister) GetRelationTuples(ctx context.Context, query *relationtuple.
 	return internalRes, nextPageToken, nil
 }
 
+func (p *Persister) GetRelationTuplesCount(ctx context.Context, query *relationtuple.RelationQuery) (*int, error) {
+	sqlQuery := p.QueryWithNetwork(ctx)
+
+	err := p.whereQuery(ctx, sqlQuery, query)
+	if err != nil {
+		return nil, err
+	}
+
+	var res relationTuples
+
+	count, err := sqlQuery.Count(&res)
+	if err != nil {
+		return nil, sqlcon.HandleError(err)
+	}
+
+	return &count, nil
+}
+
 func (p *Persister) WriteRelationTuples(ctx context.Context, rs ...*relationtuple.InternalRelationTuple) error {
 	return p.Transaction(ctx, func(ctx context.Context, _ *pop.Connection) error {
 		for _, r := range rs {

--- a/internal/persistence/sql/relationtuples_test.go
+++ b/internal/persistence/sql/relationtuples_test.go
@@ -3,6 +3,9 @@ package sql_test
 import (
 	"context"
 	stdSql "database/sql"
+	"github.com/ory/keto/internal/driver/config"
+	"github.com/ory/keto/internal/namespace"
+	"github.com/ory/keto/internal/relationtuple"
 	"strings"
 	"testing"
 	"time"
@@ -104,6 +107,70 @@ func TestRelationTupleSubjectTypeCheck(t *testing.T) {
 							strings.Contains(err.Error(), "chk_keto_rt_subject_type") || // <- normal databases
 								strings.Contains(err.Error(), "SQLSTATE 23514")) // <- mysql
 					}
+				})
+			}
+		})
+	}
+}
+
+func TestPersister_GetRelationTuplesCount(t *testing.T) {
+	nid := uuid.Must(uuid.FromString("d59f09fc-dc9e-4733-800e-bb41aba6b1ea"))
+	ns := &namespace.Namespace{ID: 1, Name: "cards"}
+
+	for _, dsn := range dbx.GetDSNs(t, false) {
+		t.Run("dsn="+dsn.Name, func(t *testing.T) {
+			ctx := context.Background()
+			reg := driver.NewTestRegistry(t, dsn)
+			require.NoError(t,
+				reg.Config(ctx).Set(config.KeyNamespaces, []*namespace.Namespace{ns}))
+
+			rts := []*relationtuple.InternalRelationTuple{
+				{
+					Namespace: ns.Name,
+					Object:    "Spade1",
+					Relation:  "r1",
+					Subject:   &relationtuple.SubjectID{ID: "s1"},
+				},
+				{
+					Namespace: ns.Name,
+					Object:    "Hearts1",
+					Relation:  "r2",
+					Subject:   &relationtuple.SubjectID{ID: "s2"},
+				},
+			}
+
+			err := reg.RelationTupleManager().WriteRelationTuples(context.Background(), rts...)
+			assert.NoError(t, err)
+
+			for _, tc := range []struct {
+				desc          string
+				query         *relationtuple.RelationQuery
+				expectedCount int
+			}{
+				{
+					desc: "Get all records count",
+					query: &relationtuple.RelationQuery{
+						Namespace: "cards",
+					},
+					expectedCount: 2,
+				},
+				{
+					desc: "get count with query defined",
+					query: &relationtuple.RelationQuery{
+						Namespace: "cards",
+						Relation:  "r1",
+					},
+					expectedCount: 1,
+				},
+			} {
+				t.Run("case="+tc.desc, func(t *testing.T) {
+					p, err := sql.NewPersister(ctx, reg, nid)
+					require.NoError(t, err)
+
+					count, err := p.GetRelationTuplesCount(ctx, tc.query)
+
+					assert.NoError(t, err)
+					assert.Equal(t, tc.expectedCount, *count)
 				})
 			}
 		})

--- a/internal/relationtuple/definitions.go
+++ b/internal/relationtuple/definitions.go
@@ -27,6 +27,7 @@ type (
 	}
 	Manager interface {
 		GetRelationTuples(ctx context.Context, query *RelationQuery, options ...x.PaginationOptionSetter) ([]*InternalRelationTuple, string, error)
+		GetRelationTuplesCount(ctx context.Context, query *RelationQuery) (*int, error)
 		WriteRelationTuples(ctx context.Context, rs ...*InternalRelationTuple) error
 		DeleteRelationTuples(ctx context.Context, rs ...*InternalRelationTuple) error
 		DeleteAllRelationTuples(ctx context.Context, query *RelationQuery) error
@@ -663,6 +664,10 @@ func (t *ManagerWrapper) GetRelationTuples(ctx context.Context, query *RelationQ
 	opts := x.GetPaginationOptions(options...)
 	t.RequestedPages = append(t.RequestedPages, opts.Token)
 	return t.Reg.RelationTupleManager().GetRelationTuples(ctx, query, append(t.PageOpts, options...)...)
+}
+
+func (t *ManagerWrapper) GetRelationTuplesCount(ctx context.Context, query *RelationQuery) (*int, error) {
+	return t.Reg.RelationTupleManager().GetRelationTuplesCount(ctx, query)
 }
 
 func (t *ManagerWrapper) WriteRelationTuples(ctx context.Context, rs ...*InternalRelationTuple) error {

--- a/internal/relationtuple/handler.go
+++ b/internal/relationtuple/handler.go
@@ -28,6 +28,11 @@ type GetResponse struct {
 	NextPageToken string `json:"next_page_token"`
 }
 
+// swagger:model getRelationTuplesCountResponse
+type GetCountResponse struct {
+	Count int `json:"count"`
+}
+
 const (
 	ReadRouteBase  = "/relation-tuples"
 	WriteRouteBase = "/admin/relation-tuples"
@@ -41,6 +46,7 @@ func NewHandler(d handlerDeps) *handler {
 
 func (h *handler) RegisterReadRoutes(r *x.ReadRouter) {
 	r.GET(ReadRouteBase, h.getRelations)
+	r.GET(ReadRouteBase+"/count", h.getRelationsCount)
 }
 
 func (h *handler) RegisterWriteRoutes(r *x.WriteRouter) {

--- a/internal/relationtuple/read_server_test.go
+++ b/internal/relationtuple/read_server_test.go
@@ -55,6 +55,26 @@ func TestReadHandlers(t *testing.T) {
 			}, respMsg)
 		})
 
+		t.Run("case=no records count is not nil", func(t *testing.T) {
+			resp, err := ts.Client().Get(ts.URL + relationtuple.ReadRouteBase + "/count?" + url.Values{
+				"namespace": {nspace.Name},
+			}.Encode())
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, "0", gjson.GetBytes(body, "count").Raw)
+
+			var respMsg relationtuple.GetCountResponse
+			require.NoError(t, json.Unmarshal(body, &respMsg))
+
+			assert.Equal(t, relationtuple.GetCountResponse{
+				Count: 0,
+			}, respMsg)
+		})
+
 		t.Run("case=returns tuples", func(t *testing.T) {
 			rts := []*relationtuple.InternalRelationTuple{
 				{


### PR DESCRIPTION
Introduces a new API that returns a count of relation tuples against relation query.

## Related issue(s)

Resolves [#824](https://github.com/ory/keto/issues/824)

⚠️ _No linked design document_

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

- grpc definition is currently missing
- Tests are missing at the moment (WIP)
