### PR TITLE
test: paralellize db tests

### DIFF
--- a/internal/e2e/full_suit_test.go
+++ b/internal/e2e/full_suit_test.go
@@ -44,12 +44,16 @@ const (
 )
 
 func Test(t *testing.T) {
+	t.Parallel()
 	for _, dsn := range dbx.GetDSNs(t, false) {
+		dsn := dsn
 		t.Run(fmt.Sprintf("dsn=%s", dsn.Name), func(t *testing.T) {
+			t.Parallel()
+
 			ctx, reg, addNamespace := newInitializedReg(t, dsn, nil)
 
 			closeServer := startServer(ctx, t, reg)
-			defer closeServer()
+			t.Cleanup(closeServer)
 
 			// The test cases start here
 			// We execute every test with all clients available
@@ -78,11 +82,13 @@ func Test(t *testing.T) {
 				t.Run(fmt.Sprintf("client=%T", cl), runCases(cl, addNamespace))
 
 				if tc, ok := cl.(transactClient); ok {
+
 					t.Run(fmt.Sprintf("transactClient=%T", cl), runTransactionCases(tc, addNamespace))
 				}
 			}
 
 			t.Run("case=metrics are served", func(t *testing.T) {
+				t.Parallel()
 				(&grpcClient{
 					readRemote:  reg.Config(ctx).ReadAPIListenOn(),
 					writeRemote: reg.Config(ctx).WriteAPIListenOn(),
@@ -90,6 +96,7 @@ func Test(t *testing.T) {
 				}).waitUntilLive(t)
 
 				t.Run("case=on "+prometheus.MetricsPrometheusPath, func(t *testing.T) {
+					t.Parallel()
 					resp, err := http.Get(fmt.Sprintf("http://%s%s", reg.Config(ctx).MetricsListenOn(), prometheus.MetricsPrometheusPath))
 					require.NoError(t, err)
 					require.Equal(t, resp.StatusCode, http.StatusOK)
@@ -99,6 +106,7 @@ func Test(t *testing.T) {
 				})
 
 				t.Run("case=not on /", func(t *testing.T) {
+					t.Parallel()
 					resp, err := http.Get(fmt.Sprintf("http://%s", reg.Config(ctx).MetricsListenOn()))
 					require.NoError(t, err)
 					require.Equal(t, resp.StatusCode, http.StatusNotFound)
@@ -109,6 +117,8 @@ func Test(t *testing.T) {
 }
 
 func TestServeConfig(t *testing.T) {
+	t.Parallel()
+
 	ctx, reg, _ := newInitializedReg(t, dbx.GetSqlite(t, dbx.SQLiteMemory), map[string]interface{}{
 		"serve.read.cors.enabled":         true,
 		"serve.read.cors.debug":           true,
@@ -117,7 +127,7 @@ func TestServeConfig(t *testing.T) {
 	})
 
 	closeServer := startServer(ctx, t, reg)
-	defer closeServer()
+	t.Cleanup(closeServer)
 
 	for !healthReady(t, "http://"+reg.Config(ctx).ReadAPIListenOn()) {
 		t.Log("Waiting for health check to be ready")

--- a/internal/e2e/transaction_cases_test.go
+++ b/internal/e2e/transaction_cases_test.go
@@ -11,6 +11,7 @@ import (
 
 func runTransactionCases(c transactClient, addNamespace func(*testing.T, ...*namespace.Namespace)) func(*testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
 		t.Run("case=create and delete", func(t *testing.T) {
 			n := &namespace.Namespace{Name: t.Name()}
 			addNamespace(t, n)

--- a/internal/persistence/sql/full_test.go
+++ b/internal/persistence/sql/full_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestPersister(t *testing.T) {
+	t.Parallel()
+
 	setup := func(t *testing.T, dsn *dbx.DsnT) (p *sql.Persister, r *driver.RegistryDefault, hook *test.Hook) {
 		r = driver.NewTestRegistry(t, dsn)
 
@@ -46,7 +48,10 @@ func TestPersister(t *testing.T) {
 	}
 
 	for _, dsn := range dbx.GetDSNs(t, false) {
+		dsn := dsn
 		t.Run(fmt.Sprintf("dsn=%s", dsn.Name), func(t *testing.T) {
+			t.Parallel()
+
 			t.Run("relationtuple.ManagerTest", func(t *testing.T) {
 				var nspaces []*namespace.Namespace
 				p, r, _ := setup(t, dsn)

--- a/internal/persistence/sql/migrations/migratest/migration_test.go
+++ b/internal/persistence/sql/migrations/migratest/migration_test.go
@@ -104,10 +104,14 @@ func check(mb *popx.MigrationBox) error {
 }
 
 func TestMigrations(t *testing.T) {
+	t.Parallel()
 	const debugOnDisk = false
 
 	for _, db := range dbx.GetDSNs(t, debugOnDisk) {
+		db := db
 		t.Run("dsn="+db.Name, func(t *testing.T) {
+			t.Parallel()
+
 			db.MigrateUp, db.MigrateDown = false, false
 
 			ctx := context.Background()

--- a/internal/persistence/sql/migrations/single_table_test.go
+++ b/internal/persistence/sql/migrations/single_table_test.go
@@ -18,10 +18,14 @@ import (
 )
 
 func TestToSingleTableMigrator(t *testing.T) {
+	t.Parallel()
 	const debugOnDisk = false
 
 	for _, dsn := range dbx.GetDSNs(t, debugOnDisk) {
+		dsn := dsn
 		t.Run("db="+dsn.Name, func(t *testing.T) {
+			t.Parallel()
+
 			r := driver.NewTestRegistry(t, dsn)
 			ctx := context.Background()
 			var nn []*namespace.Namespace
@@ -162,10 +166,14 @@ func TestToSingleTableMigrator(t *testing.T) {
 }
 
 func TestToSingleTableMigrator_HasLegacyTable(t *testing.T) {
+	t.Parallel()
 	const debugOnDisk = false
 
 	for _, dsn := range dbx.GetDSNs(t, debugOnDisk) {
+		dsn := dsn
 		t.Run("db="+dsn.Name, func(t *testing.T) {
+			t.Parallel()
+
 			t.Run("case=simple detection", func(t *testing.T) {
 				ctx := context.Background()
 				reg := driver.NewTestRegistry(t, dsn)

--- a/internal/persistence/sql/pagination_test.go
+++ b/internal/persistence/sql/pagination_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPaginationToken(t *testing.T) {
+	t.Parallel()
+
 	for i, tc := range []struct {
 		size            int
 		token           string

--- a/internal/persistence/sql/relationtuples_test.go
+++ b/internal/persistence/sql/relationtuples_test.go
@@ -39,8 +39,12 @@ func rt(nw *networkx.Network, setSID, setNID, setO, setR bool) *sql.RelationTupl
 }
 
 func TestRelationTupleSubjectTypeCheck(t *testing.T) {
+	t.Parallel()
+
 	for _, dsn := range dbx.GetDSNs(t, false) {
+		dsn := dsn
 		t.Run("dsn="+dsn.Name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			reg := driver.NewTestRegistry(t, dsn)
 			c, err := reg.PopConnection(context.Background())
@@ -93,7 +97,9 @@ func TestRelationTupleSubjectTypeCheck(t *testing.T) {
 					success: false,
 				},
 			} {
+				tc := tc
 				t.Run("case="+tc.desc, func(t *testing.T) {
+					t.Parallel()
 					err = c.Create(rt(nw, tc.setSID, tc.setNID, tc.setO, tc.setR))
 
 					if tc.success {

--- a/internal/persistence/sql/uuid_mapping_test.go
+++ b/internal/persistence/sql/uuid_mapping_test.go
@@ -30,8 +30,12 @@ func assertCheckErr(t assert.TestingT, err error, msgAndArgs ...interface{}) boo
 }
 
 func TestUUIDMapping(t *testing.T) {
+	t.Parallel()
+
 	for _, dsn := range dbx.GetDSNs(t, false) {
+		dsn := dsn
 		t.Run("dsn="+dsn.Name, func(t *testing.T) {
+			t.Parallel()
 			reg := driver.NewTestRegistry(t, dsn)
 			c, err := reg.PopConnection(context.Background())
 			require.NoError(t, err)
@@ -69,7 +73,9 @@ func TestUUIDMapping(t *testing.T) {
 				},
 				assertErr: assert.NoError,
 			}} {
+				tc := tc
 				t.Run("case="+tc.desc, func(t *testing.T) {
+					t.Parallel()
 					err := c.Create(tc.mappings)
 					tc.assertErr(t, err)
 				})

--- a/internal/x/dbx/dsn_testutils.go
+++ b/internal/x/dbx/dsn_testutils.go
@@ -193,12 +193,12 @@ func GetSqlite(t testing.TB, mode sqliteMode) *DsnT {
 		})
 	case SQLiteFile:
 		t.Cleanup(func() {
-			_ = os.Remove("TestDB.sqlite")
+			_ = os.Remove(fmt.Sprintf("TestDB_%s.sqlite", t.Name()))
 		})
 		fallthrough
 	case SQLiteDebug:
 		dsn.Name = "sqlite"
-		dsn.Conn = "sqlite://file:TestDB.sqlite?_fk=true"
+		dsn.Conn = fmt.Sprintf("sqlite://file:TestDB_%s.sqlite?_fk=true", t.Name())
 	}
 
 	return dsn

--- a/internal/x/dbx/dsn_testutils_test.go
+++ b/internal/x/dbx/dsn_testutils_test.go
@@ -50,7 +50,9 @@ func Test_withDbName(t *testing.T) {
 
 func Test_GetDSNs_can_connect_to_each_db(t *testing.T) {
 	for _, db := range GetDSNs(t, false) {
+		db := db
 		t.Run("dsn="+db.Name, func(t *testing.T) {
+			t.Parallel()
 			conn, err := pop.NewConnection(&pop.ConnectionDetails{URL: db.Conn})
 			require.NoError(t, err)
 			assert.NoError(t, conn.Open())


### PR DESCRIPTION
This PR enables running the database tests in parallel.

This PR is done on top of `feat/uuid-mapping`, which contains the code to run each DB test in a separate DB (on the same server). We can rebase this PR/commit on master once #840 is merged.