### PR TITLE
feat: user-set rewrites

### DIFF
--- a/internal/check/engine.go
+++ b/internal/check/engine.go
@@ -3,14 +3,16 @@ package check
 import (
 	"context"
 	"errors"
-
-	"github.com/ory/keto/internal/driver/config"
-	"github.com/ory/keto/internal/x/graph"
+	"time"
 
 	"github.com/ory/herodot"
 
+	"github.com/ory/keto/internal/driver/config"
+	"github.com/ory/keto/internal/namespace"
+	"github.com/ory/keto/internal/namespace/ast"
 	"github.com/ory/keto/internal/relationtuple"
 	"github.com/ory/keto/internal/x"
+	"github.com/ory/keto/internal/x/graph"
 )
 
 type (
@@ -25,6 +27,10 @@ type (
 		config.Provider
 		x.LoggerProvider
 	}
+
+	// Type aliases for shorter signatures
+	RelationTuple = relationtuple.InternalRelationTuple
+	Query         = relationtuple.RelationQuery
 )
 
 func NewEngine(d EngineDependencies) *Engine {
@@ -33,16 +39,18 @@ func NewEngine(d EngineDependencies) *Engine {
 	}
 }
 
-func (e *Engine) subjectIsAllowed(
+func (e *Engine) checkDirect(
 	ctx context.Context,
-	requested *relationtuple.InternalRelationTuple,
-	rels []*relationtuple.InternalRelationTuple,
+	requested *RelationTuple,
+	rels []*RelationTuple,
 	restDepth int,
-) (bool, error) {
+) checkFn {
 	// This is the same as the graph problem "can requested.Subject be reached from requested.Object through the first outgoing edge requested.Relation"
 	//
 	// We implement recursive depth-first search here.
 	// TODO replace by more performant algorithm: https://github.com/ory/keto/issues/483
+
+	var indirectChecks []checkFn
 
 	for _, sr := range rels {
 		ctx, wasAlreadyVisited := graph.CheckAndAddVisited(ctx, sr.Subject)
@@ -53,7 +61,7 @@ func (e *Engine) subjectIsAllowed(
 		// we only have to check Subject here as we know that sr was reached from requested.ObjectID, requested.Relation through 0...n indirections
 		if requested.Subject.Equals(sr.Subject) {
 			// found the requested relation
-			return true, nil
+			return isMemberCheckFn
 		}
 
 		sub, isSubjectSet := sr.Subject.(*relationtuple.SubjectSet)
@@ -62,62 +70,319 @@ func (e *Engine) subjectIsAllowed(
 		}
 
 		// expand the set by one indirection; paginated
-		allowed, err := e.checkOneIndirectionFurther(
+
+		// TODO(hperl): Convert everything to concurrent request.
+		indirectChecks = append(indirectChecks, e.checkOneIndirectionFurther(
 			ctx,
 			requested,
-			&relationtuple.RelationQuery{Object: sub.Object, Relation: sub.Relation, Namespace: sub.Namespace},
+			&Query{Object: sub.Object, Relation: sub.Relation, Namespace: sub.Namespace},
 			restDepth-1,
-		)
-		if err != nil {
-			return false, err
-		}
-		if allowed {
-			return true, nil
-		}
+		))
 	}
-
-	return false, nil
+	return unionCheckFn(ctx, indirectChecks)
 }
 
 func (e *Engine) checkOneIndirectionFurther(
 	ctx context.Context,
-	requested *relationtuple.InternalRelationTuple,
-	expandQuery *relationtuple.RelationQuery,
+	requested *RelationTuple,
+	expandQuery *Query,
 	restDepth int,
-) (bool, error) {
-	if restDepth <= 0 {
-		e.d.Logger().WithFields(requested.ToLoggerFields()).Debug("reached max-depth, therefore this query will not be further expanded")
-		return false, nil
-	}
+) checkFn {
+	return func(ctx context.Context, resultCh chan<- checkResult) {
+		e.d.Logger().
+			WithField("request", requested.String()).
+			WithField("query", expandQuery.String()).
+			Trace("check one direction further")
 
-	// an empty page token denotes the first page (as tokens are opaque)
-	var prevPage string
-
-	for {
-		nextRels, nextPage, err := e.d.RelationTupleManager().GetRelationTuples(ctx, expandQuery, x.WithToken(prevPage))
-		// herodot.ErrNotFound occurs when the namespace is unknown
-		if errors.Is(err, herodot.ErrNotFound) {
-			return false, nil
-		} else if err != nil {
-			return false, err
+		if restDepth < 0 {
+			e.d.Logger().WithFields(requested.ToLoggerFields()).Debug("reached max-depth, therefore this query will not be further expanded")
+			resultCh <- ResultNotMember
+			return
 		}
 
-		allowed, err := e.subjectIsAllowed(ctx, requested, nextRels, restDepth)
+		// an empty page token denotes the first page (as tokens are opaque)
+		var prevPage string
 
-		// loop through pages until either allowed, end of pages, or an error occurred
-		if allowed || nextPage == "" || err != nil {
-			return allowed, err
+		subcheckCh := make(chan checkResult)
+
+		// used to report to the number of subchecks (which we only know after all pages)
+		totalNumOfSubchecksCh := make(chan int)
+		consumer := func() {
+			subCheckCount := 0
+			totalNumOfSubchecks := 0
+			for {
+				select {
+				case result := <-subcheckCh:
+					subCheckCount++
+					if result.Err != nil || result.Membership == IsMember || totalNumOfSubchecks == subCheckCount {
+						resultCh <- result
+						return
+					}
+				case totalNumOfSubchecks = <-totalNumOfSubchecksCh:
+					if totalNumOfSubchecks == subCheckCount {
+						resultCh <- ResultNotMember
+						return
+					}
+
+				case <-ctx.Done():
+					resultCh <- checkResult{Err: context.Canceled}
+					return
+				}
+			}
 		}
+		go consumer()
 
-		prevPage = nextPage
+		totalNumOfSubchecks := 0
+		for {
+			totalNumOfSubchecks++
+			nextRels, nextPage, err := e.d.RelationTupleManager().GetRelationTuples(ctx, expandQuery, x.WithToken(prevPage))
+			// herodot.ErrNotFound occurs when the namespace is unknown
+			if errors.Is(err, herodot.ErrNotFound) {
+				subcheckCh <- ResultNotMember
+				break
+			} else if err != nil {
+				subcheckCh <- checkResult{Err: err}
+				break
+			}
+
+			check := e.checkDirect(ctx, requested, nextRels, restDepth-1)
+			go check(ctx, subcheckCh)
+
+			// loop through pages until either allowed, end of pages, or an error occurred
+			if nextPage == "" {
+				break
+			}
+			prevPage = nextPage
+		}
+		// Now that we know the total amount of subchecks we need to once report it.
+		totalNumOfSubchecksCh <- totalNumOfSubchecks
 	}
 }
 
-func (e *Engine) SubjectIsAllowed(ctx context.Context, r *relationtuple.InternalRelationTuple, restDepth int) (bool, error) {
-	// global max-depth takes precedence when it is the lesser or if the request max-depth is less than or equal to 0
+type membership int
+
+const (
+	MembershipUnknown membership = iota
+	IsMember
+	NotMember
+)
+
+type checkResult struct {
+	Membership membership
+	Err        error
+}
+
+var (
+	ResultIsMember  = checkResult{Membership: IsMember}
+	ResultNotMember = checkResult{Membership: NotMember}
+)
+
+type checkFn func(ctx context.Context, resultCh chan<- checkResult)
+
+func (e *Engine) SubjectIsAllowed(ctx context.Context, r *RelationTuple, restDepth int) (bool, error) {
+	// global max-depth takes precedence when it is the lesser or if the request
+	// max-depth is less than or equal to 0
 	if globalMaxDepth := e.d.Config(ctx).MaxReadDepth(); restDepth <= 0 || globalMaxDepth < restDepth {
 		restDepth = globalMaxDepth
 	}
+	result := union(ctx, []checkFn{e.checkIsAllowed(ctx, r, restDepth+1)})
 
-	return e.checkOneIndirectionFurther(ctx, r, &relationtuple.RelationQuery{Object: r.Object, Relation: r.Relation, Namespace: r.Namespace}, restDepth)
+	return result.Membership == IsMember, result.Err
+}
+
+func errorCheckFn(err error) checkFn {
+	return func(_ context.Context, resultCh chan<- checkResult) {
+		resultCh <- checkResult{Err: err}
+	}
+}
+
+var isMemberCheckFn checkFn = func(_ context.Context, resultCh chan<- checkResult) {
+	resultCh <- checkResult{Membership: IsMember}
+}
+
+func (e *Engine) checkIsAllowed(ctx context.Context, r *RelationTuple, restDepth int) checkFn {
+	e.d.Logger().
+		WithField("request", r.String()).
+		Trace("check is allowed")
+
+	directFn := e.checkOneIndirectionFurther(ctx, r,
+		&Query{
+			Object:    r.Object,
+			Relation:  r.Relation,
+			Namespace: r.Namespace,
+		}, restDepth)
+
+	checks := []checkFn{directFn}
+
+	relation, err := e.astRelationFor(ctx, r)
+	if err == nil && relation.UsersetRewrite != nil {
+		checks = append(checks, e.checkUsersetRewrite(ctx, r, relation.UsersetRewrite))
+	}
+
+	return unionCheckFn(ctx, checks)
+}
+
+func unionCheckFn(ctx context.Context, checks []checkFn) checkFn {
+	return func(ctx context.Context, resultCh chan<- checkResult) {
+		resultCh <- union(ctx, checks)
+	}
+}
+
+func checkNotImplemented(_ context.Context, resultCh chan<- checkResult) {
+	resultCh <- checkResult{Err: errors.New("not implemented")}
+}
+
+type setOperation func(ctx context.Context, checks []checkFn) checkResult
+
+func (e *Engine) checkUsersetRewrite(ctx context.Context, r *RelationTuple, rewrite *ast.UsersetRewrite) checkFn {
+	e.d.Logger().
+		WithField("request", r.String()).
+		Trace("check userset rewrite")
+
+	var (
+		op     setOperation
+		checks []checkFn
+	)
+	switch rewrite.Operation {
+	case ast.SetOperationUnion:
+		op = union
+	case ast.SetOperationExclusion:
+		return checkNotImplemented
+	case ast.SetOperationIntersection:
+		return checkNotImplemented
+	default:
+		return checkNotImplemented
+	}
+
+	for _, c := range rewrite.Children.ComputedUsersets {
+		c := c
+		checks = append(checks, e.checkComputedUserset(ctx, r, &c))
+	}
+	for _, c := range rewrite.Children.TupleToUsersets {
+		c := c
+		checks = append(checks, e.checkTupleToUserset(ctx, r, &c))
+	}
+
+	return func(ctx context.Context, resultCh chan<- checkResult) {
+		resultCh <- op(ctx, checks)
+	}
+}
+
+func (e *Engine) checkComputedUserset(ctx context.Context, r *RelationTuple, userset *ast.ComputedUserset) checkFn {
+	e.d.Logger().
+		WithField("request", r.String()).
+		WithField("computed userset relation", userset.Relation).
+		Trace("check computed userset")
+
+	return e.checkIsAllowed(
+		ctx,
+		&RelationTuple{
+			Namespace: r.Namespace,
+			Object:    r.Object,
+			Relation:  userset.Relation,
+			Subject:   r.Subject,
+		},
+		100,
+	)
+}
+
+func (e *Engine) checkTupleToUserset(ctx context.Context, r *RelationTuple, userset *ast.TupleToUserset) checkFn {
+	e.d.Logger().
+		WithField("request", r.String()).
+		WithField("tuple to userset relation", userset.Relation).
+		WithField("tuple to userset computed", userset.ComputedUsersetRelation).
+		Trace("check tuple to userset")
+
+	return func(ctx context.Context, resultCh chan<- checkResult) {
+		var (
+			prevPage, nextPage string
+			rts, rtsPage       []*RelationTuple
+			err                error
+		)
+		for nextPage = "x"; nextPage != ""; prevPage = nextPage {
+			rtsPage, nextPage, err = e.d.RelationTupleManager().GetRelationTuples(
+				ctx,
+				&Query{
+					Namespace: r.Namespace,
+					Object:    r.Object,
+					Relation:  userset.Relation,
+				},
+				x.WithToken(prevPage)) // TODO pagination
+			if err != nil {
+				resultCh <- checkResult{Err: err}
+				return
+			}
+			rts = append(rts, rtsPage...)
+		}
+		checks := []checkFn{}
+		for _, rt := range rts {
+			if rt.Subject.SubjectSet() == nil {
+				continue
+			}
+			checks = append(checks, e.checkIsAllowed(
+				ctx,
+				&RelationTuple{
+					Namespace: rt.Subject.SubjectSet().Namespace,
+					Object:    rt.Subject.SubjectSet().Object,
+					Relation:  userset.ComputedUsersetRelation,
+					Subject:   r.Subject,
+				},
+				100,
+			))
+		}
+		resultCh <- union(ctx, checks)
+	}
+}
+
+func (e *Engine) astRelationFor(ctx context.Context, r *RelationTuple) (*ast.Relation, error) {
+	ns, err := e.namespaceFor(ctx, r)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range ns.Relations {
+		if rel.Name == r.Relation {
+			return &rel, nil
+		}
+	}
+	return nil, errors.New("relation not found")
+}
+
+func (e *Engine) namespaceFor(ctx context.Context, r *RelationTuple) (*namespace.Namespace, error) {
+	namespaceManager, err := e.d.Config(ctx).NamespaceManager()
+	if err != nil {
+		return nil, err
+	}
+	ns, err := namespaceManager.GetNamespaceByName(ctx, r.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return ns, nil
+}
+
+func union(ctx context.Context, checks []checkFn) checkResult {
+	if len(checks) == 0 {
+		return ResultNotMember
+	}
+
+	resultCh := make(chan checkResult, len(checks))
+	childCtx, cancelFn := context.WithTimeout(ctx, 1*time.Second)
+	defer cancelFn()
+
+	for _, check := range checks {
+		go check(childCtx, resultCh)
+	}
+
+	for i := 0; i < len(checks); i++ {
+		select {
+		case result := <-resultCh:
+			// We return either the first error or the first success.
+			if result.Err != nil || result.Membership == IsMember {
+				return result
+			}
+		case <-ctx.Done():
+			return checkResult{Err: context.Canceled}
+		}
+	}
+
+	return ResultNotMember
 }

--- a/internal/check/userset_rewrites_test.go
+++ b/internal/check/userset_rewrites_test.go
@@ -1,0 +1,137 @@
+package check_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/keto/internal/check"
+	"github.com/ory/keto/internal/namespace"
+	"github.com/ory/keto/internal/namespace/ast"
+	"github.com/ory/keto/internal/relationtuple"
+)
+
+var docsNS = namespace.Namespace{Name: "docs",
+	ID: 1,
+	Relations: []ast.Relation{
+		{
+			Name: "owner",
+		},
+		{
+			Name: "editor",
+			UsersetRewrite: &ast.UsersetRewrite{
+				Children: ast.Children{
+					ComputedUsersets: []ast.ComputedUserset{
+						{
+							Relation: "owner",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "viewer",
+			UsersetRewrite: &ast.UsersetRewrite{
+				Children: ast.Children{
+					ComputedUsersets: []ast.ComputedUserset{{
+						Relation: "editor",
+					}},
+					TupleToUsersets: []ast.TupleToUserset{{
+						Relation:                "parent",
+						ComputedUsersetRelation: "viewer",
+					}},
+				},
+			},
+		},
+	},
+}
+
+func insertFixtures(t *testing.T, m relationtuple.Manager, tuples []string) {
+	t.Helper()
+	relationTuples := make([]*relationtuple.InternalRelationTuple, len(tuples))
+	var err error
+	for i, tuple := range tuples {
+		relationTuples[i], err = relationtuple.InternalFromString(tuple)
+		require.NoError(t, err)
+	}
+	require.NoError(t, m.WriteRelationTuples(context.Background(), relationTuples...))
+}
+
+func TestUsersetRewrites_DocsExample(t *testing.T) {
+	ctx := context.Background()
+
+	reg := newDepsProvider(t, []*namespace.Namespace{&docsNS})
+	reg.Logger().Logger.SetLevel(logrus.TraceLevel)
+	nsMgr, err := reg.Config(ctx).NamespaceManager()
+	require.NoError(t, err)
+	ns, err := nsMgr.GetNamespaceByName(ctx, docsNS.Name)
+	require.NoError(t, err)
+	require.Equal(t, &docsNS, ns)
+
+	insertFixtures(t, reg.RelationTupleManager(), []string{
+		"docs:document#owner@user",                  // user owns doc
+		"docs:doc_in_folder#parent@docs:folder#...", // doc_in_folder is in folder
+		"docs:folder#owner@user",                    // user owns folder
+
+		// Folder hierarchy folder_a -> folder_b -> folder_c -> file
+		// and folder_a is owned by user. Then user should have access to file.
+		"docs:file#parent@docs:folder_c#...",
+		"docs:folder_c#parent@docs:folder_b#...",
+		"docs:folder_b#parent@docs:folder_a#...",
+		"docs:folder_a#owner@user",
+	})
+
+	e := check.NewEngine(reg)
+
+	testCases := []struct {
+		query   string
+		allowed bool
+	}{{
+		// direct
+		query:   "docs:document#owner@user",
+		allowed: true,
+	}, {
+		// userset rewrite
+		query:   "docs:document#editor@user",
+		allowed: true,
+	}, {
+		// transitive userset rewrite
+		query:   "docs:document#viewer@user",
+		allowed: true,
+	}, {
+		query:   "docs:document#editor@nobody",
+		allowed: false,
+	}, {
+		query:   "docs:folder#viewer@user",
+		allowed: true,
+	}, {
+		// tuple to userset
+		query:   "docs:doc_in_folder#viewer@user",
+		allowed: true,
+	}, {
+		// tuple to userset
+		query:   "docs:doc_in_folder#viewer@nobody",
+		allowed: false,
+	}, {
+		// tuple to userset
+		query:   "docs:another_doc#viewer@user",
+		allowed: false,
+	}, {
+		query:   "docs:file#viewer@user",
+		allowed: true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.query, func(t *testing.T) {
+			rt, err := relationtuple.InternalFromString(tc.query)
+			require.NoError(t, err)
+
+			res, err := e.SubjectIsAllowed(ctx, rt, 100)
+			require.NoError(t, err)
+			assert.Equal(t, tc.allowed, res)
+		})
+	}
+}

--- a/internal/namespace/ast/ast_definitions.go
+++ b/internal/namespace/ast/ast_definitions.go
@@ -1,0 +1,35 @@
+package ast
+
+type (
+	Relation struct {
+		Name           string
+		UsersetRewrite *UsersetRewrite
+	}
+
+	UsersetRewrite struct {
+		Operation SetOperation
+		Children  Children
+	}
+
+	Children struct {
+		ComputedUsersets []ComputedUserset
+		TupleToUsersets  []TupleToUserset
+	}
+
+	ComputedUserset struct {
+		Relation string
+	}
+
+	TupleToUserset struct {
+		Relation                string
+		ComputedUsersetRelation string
+	}
+)
+
+type SetOperation int
+
+const (
+	SetOperationUnion SetOperation = iota
+	SetOperationIntersection
+	SetOperationExclusion
+)

--- a/internal/namespace/definitions.go
+++ b/internal/namespace/definitions.go
@@ -3,6 +3,8 @@ package namespace
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/ory/keto/internal/namespace/ast"
 )
 
 type (
@@ -10,6 +12,8 @@ type (
 		ID     int32           `json:"id" db:"-" toml:"id"`
 		Name   string          `json:"name" db:"-" toml:"name"`
 		Config json.RawMessage `json:"config,omitempty" db:"-" toml:"config,omitempty"`
+
+		Relations []ast.Relation `json:"-" db:"-"`
 	}
 	Manager interface {
 		GetNamespaceByName(ctx context.Context, name string) (*Namespace, error)

--- a/internal/relationtuple/definitions.go
+++ b/internal/relationtuple/definitions.go
@@ -270,6 +270,9 @@ func (s SubjectID) MarshalJSON() ([]byte, error) {
 }
 
 func (r *InternalRelationTuple) String() string {
+	if r == nil {
+		return "(nil)"
+	}
 	return fmt.Sprintf("%s:%s#%s@%s", r.Namespace, r.Object, r.Relation, r.Subject)
 }
 
@@ -302,6 +305,10 @@ func (r *InternalRelationTuple) FromString(s string) (*InternalRelationTuple, er
 	}
 
 	return r, nil
+}
+
+func InternalFromString(s string) (*InternalRelationTuple, error) {
+	return (&InternalRelationTuple{}).FromString(s)
 }
 
 func (r *InternalRelationTuple) DeriveSubject() *SubjectSet {

--- a/internal/relationtuple/manager_isolation.go
+++ b/internal/relationtuple/manager_isolation.go
@@ -112,5 +112,17 @@ func IsolationTest(t *testing.T, m0, m1 Manager, addNamespace func(context.Conte
 				assert.Equal(t, rts[1:], r1)
 			})
 		})
+
+		t.Run("case=cancelled", func(t *testing.T) {
+			reset(t, m0, m1)
+			ctx, cancel := context.WithCancel(ctx)
+
+			require.NoError(t, m0.WriteRelationTuples(ctx, rts...))
+
+			cancel()
+
+			_, _, err := m0.GetRelationTuples(ctx, &RelationQuery{Namespace: nspace})
+			assert.ErrorIs(t, err, context.Canceled)
+		})
 	})
 }


### PR DESCRIPTION
This PR implements userset rewrites as described in the Zanzibar paper (https://storage.googleapis.com/pub-tools-public-publication-data/pdf/10683a8987dbf0c6d4edcafb9b4f05cc9de5974a.pdf). This is work-in-progress.

The first part of the implementation focusses on checks against an internal representation of the namespace configuration, a configuration similar to the protobufs in the Zanzibar paper.

A later part would then translate from a high-level configuration language down to the internal representation.


## Related issue(s)

https://github.com/ory/keto/issues/263


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](docs/docs).

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
