### PR TITLE
chore: enable Dependabot for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: 'daily'
+  - package-ecosystem: 'docker'
+    directory: '/.docker'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
Enable Dependabot for Docker.