### PR TITLE
fix: enable telemetry by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,6 @@ tools/brew:
 .bin/clidoc:
 		go build -o .bin/clidoc ./cmd/clidoc/.
 
-docs/cli: tools/clidoc
-		clidoc .
-
 .PHONY: format
 format: tools/goimports node_modules
 		goimports -w -local github.com/ory/keto *.go internal cmd contrib ketoctx embedx

--- a/cmd/server/serve.go
+++ b/cmd/server/serve.go
@@ -15,9 +15,6 @@
 package server
 
 import (
-	"os"
-	"strconv"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ory/keto/cmd/helpers"
@@ -46,17 +43,8 @@ on configuration options, open the configuration documentation:
 			return reg.ServeAllSQA(cmd)
 		},
 	}
-	disableTelemetry, err := strconv.ParseBool(os.Getenv("DISABLE_TELEMETRY"))
-	if err != nil {
-		disableTelemetry = true
-	}
-	sqaOptOut, err := strconv.ParseBool(os.Getenv("SQA_OPT_OUT"))
-	if err != nil {
-		sqaOptOut = true
-	}
 
-	cmd.Flags().Bool("disable-telemetry", disableTelemetry, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
-	cmd.Flags().Bool("sqa-opt-out", sqaOptOut, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
+	cmd.Flags().Bool("sqa-opt-out", false, "Disable anonymized telemetry reports - for more information please visit https://www.ory.sh/docs/ecosystem/sqa")
 
 	return cmd
 }


### PR DESCRIPTION
The problem was that `strconv.ParseBool(os.Getenv("SQA_OPT_OUT"))` would result in an error when the env var would not be set (default), and therefore the default behavior is to disable telemetry.
The env var is handled inside of the metricsx package anyways: https://github.com/ory/x/blob/f721c4ee23a6965ae39dc2e99c0ff2f4eb161410/metricsx/middleware.go#L185