### PR TITLE
fix: hide relation tuples with deleted namespace

### DIFF
--- a/internal/e2e/full_suit_test.go
+++ b/internal/e2e/full_suit_test.go
@@ -50,7 +50,7 @@ func Test(t *testing.T) {
 		t.Run(fmt.Sprintf("dsn=%s", dsn.Name), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, reg, addNamespace := newInitializedReg(t, dsn, nil)
+			ctx, reg, namespaceTestMgr := newInitializedReg(t, dsn, nil)
 
 			closeServer := startServer(ctx, t, reg)
 			t.Cleanup(closeServer)
@@ -79,10 +79,10 @@ func Test(t *testing.T) {
 					writeRemote: reg.Config(ctx).WriteAPIListenOn(),
 				},
 			} {
-				t.Run(fmt.Sprintf("client=%T", cl), runCases(cl, addNamespace))
+				t.Run(fmt.Sprintf("client=%T", cl), runCases(cl, namespaceTestMgr))
 
 				if tc, ok := cl.(transactClient); ok {
-					t.Run(fmt.Sprintf("transactClient=%T", cl), runTransactionCases(tc, addNamespace))
+					t.Run(fmt.Sprintf("transactClient=%T", cl), runTransactionCases(tc, namespaceTestMgr))
 				}
 			}
 

--- a/internal/e2e/helpers.go
+++ b/internal/e2e/helpers.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/ory/keto/internal/x/dbx"
@@ -10,8 +9,6 @@ import (
 	"github.com/ory/keto/internal/relationtuple"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/ory/keto/internal/x"
 
 	"github.com/ory/x/configx"
 	"github.com/phayes/freeport"
@@ -26,7 +23,43 @@ import (
 	"github.com/ory/keto/internal/driver"
 )
 
-func newInitializedReg(t testing.TB, dsn *dbx.DsnT, cfgOverwrites map[string]interface{}) (context.Context, driver.Registry, func(*testing.T, ...*namespace.Namespace)) {
+type namespaceTestManager struct {
+	reg     driver.Registry
+	ctx     context.Context
+	nspaces []*namespace.Namespace
+	nextID  int32
+}
+
+func (m *namespaceTestManager) add(t *testing.T, nn ...*namespace.Namespace) {
+	for _, n := range nn {
+		n.ID = m.nextID
+		m.nextID++
+		m.nspaces = append(m.nspaces, n)
+	}
+
+	require.NoError(t, m.reg.Config(m.ctx).Set(config.KeyNamespaces, m.nspaces))
+
+	t.Cleanup(func() {
+		for _, n := range nn {
+			require.NoError(t, m.reg.RelationTupleManager().DeleteAllRelationTuples(m.ctx, &relationtuple.RelationQuery{
+				Namespace: n.Name,
+			}))
+		}
+	})
+}
+
+func (m *namespaceTestManager) remove(t *testing.T, id int32) {
+	newNamespaces := make([]*namespace.Namespace, 0, len(m.nspaces))
+	for _, n := range m.nspaces {
+		if n.ID != id {
+			newNamespaces = append(newNamespaces, n)
+		}
+	}
+	m.nspaces = newNamespaces
+	require.NoError(t, m.reg.Config(m.ctx).Set(config.KeyNamespaces, m.nspaces))
+}
+
+func newInitializedReg(t testing.TB, dsn *dbx.DsnT, cfgOverwrites map[string]interface{}) (context.Context, driver.Registry, *namespaceTestManager) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() {
 		cancel()
@@ -62,32 +95,12 @@ func newInitializedReg(t testing.TB, dsn *dbx.DsnT, cfgOverwrites map[string]int
 	require.NoError(t, reg.MigrateUp(ctx))
 	assertMigrated(ctx, t, reg)
 
-	nspaces := make([]*namespace.Namespace, 0)
-	addNamespaces := func(t *testing.T, nn ...*namespace.Namespace) {
-		for _, n := range nn {
-			n.ID = int32(len(nspaces))
-			nspaces = append(nspaces, n)
-		}
-
-		require.NoError(t, reg.Config(ctx).Set(config.KeyNamespaces, nspaces))
-
-		t.Cleanup(func() {
-			for _, n := range nn {
-				err := errors.New("not nil")
-				var pt string
-				var ts []*relationtuple.InternalRelationTuple
-				for pt != "" || err != nil {
-					ts, pt, err = reg.RelationTupleManager().GetRelationTuples(ctx, &relationtuple.RelationQuery{
-						Namespace: n.Name,
-					}, x.WithToken(pt))
-					require.NoError(t, err)
-					require.NoError(t, reg.RelationTupleManager().DeleteRelationTuples(ctx, ts...))
-				}
-			}
-		})
+	return ctx, reg, &namespaceTestManager{
+		reg:     reg,
+		ctx:     ctx,
+		nspaces: []*namespace.Namespace{},
 	}
 
-	return ctx, reg, addNamespaces
 }
 
 func assertMigrated(ctx context.Context, t testing.TB, r driver.Registry) {

--- a/internal/e2e/transaction_cases_test.go
+++ b/internal/e2e/transaction_cases_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/ory/keto/internal/relationtuple"
 )
 
-func runTransactionCases(c transactClient, addNamespace func(*testing.T, ...*namespace.Namespace)) func(*testing.T) {
+func runTransactionCases(c transactClient, m *namespaceTestManager) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 		t.Run("case=create and delete", func(t *testing.T) {
 			n := &namespace.Namespace{Name: t.Name()}
-			addNamespace(t, n)
+			m.add(t, n)
 
 			tuples := []*relationtuple.InternalRelationTuple{
 				{
@@ -55,7 +55,7 @@ func runTransactionCases(c transactClient, addNamespace func(*testing.T, ...*nam
 		t.Run("case=expand-api-display-access docs code sample", func(t *testing.T) {
 			files := &namespace.Namespace{Name: t.Name() + "files"}
 			directories := &namespace.Namespace{Name: t.Name() + "directories"}
-			addNamespace(t, files, directories)
+			m.add(t, files, directories)
 
 			tuples := []*relationtuple.InternalRelationTuple{
 				{

--- a/internal/persistence/sql/full_test.go
+++ b/internal/persistence/sql/full_test.go
@@ -46,6 +46,11 @@ func TestPersister(t *testing.T) {
 			require.NoError(t, r.Config(ctx).Set(config.KeyNamespaces, nspaces))
 		}
 	}
+	removeAllNamespaces := func(r driver.Registry, nspaces []*namespace.Namespace) func(context.Context, *testing.T) {
+		return func(ctx context.Context, t *testing.T) {
+			require.NoError(t, r.Config(ctx).Set(config.KeyNamespaces, []*namespace.Namespace{}))
+		}
+	}
 
 	for _, dsn := range dbx.GetDSNs(t, false) {
 		dsn := dsn
@@ -56,7 +61,7 @@ func TestPersister(t *testing.T) {
 				var nspaces []*namespace.Namespace
 				p, r, _ := setup(t, dsn)
 
-				relationtuple.ManagerTest(t, p, addNamespace(r, nspaces))
+				relationtuple.ManagerTest(t, p, addNamespace(r, nspaces), removeAllNamespaces(r, nspaces))
 			})
 
 			t.Run("relationtuple.IsolationTest", func(t *testing.T) {


### PR DESCRIPTION
Fixes #946 