### PR TITLE
chore: silence false positive G112

### DIFF
--- a/internal/driver/daemon.go
+++ b/internal/driver/daemon.go
@@ -155,6 +155,7 @@ func (r *RegistryDefault) serveMetrics(ctx context.Context, done chan<- struct{}
 		defer cancel()
 
 		eg := &errgroup.Group{}
+		// nolint: gosec,G112 graceful.WithDefaults already sets a timeout
 		s := graceful.WithDefaults(&http.Server{
 			Handler: r.metricsRouter(ctx),
 			Addr:    r.Config(ctx).MetricsListenOn(),
@@ -199,6 +200,7 @@ func multiplexPort(ctx context.Context, log *logrusx.Logger, addr string, router
 	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpL := m.Match(cmux.HTTP1())
 
+	// nolint: gosec,G112 graceful.WithDefaults already sets a timeout
 	restS := graceful.WithDefaults(&http.Server{
 		Handler: router,
 	})


### PR DESCRIPTION
G112 is a false positive since we already set a read timeout for the HTTP server.