### PR TITLE
feat: namespace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 **/*.sqlite-journal
 .vscode/
 .fuzzer/
+keto

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,4 +1,7 @@
 only-fixed: true
 ignore:
+  # see https://github.com/anchore/grype/issues/558
   - vulnerability: CVE-2015-5237
-  - vulnerability: CVE-2022-30065
+  - vulnerability: CVE-2021-22570
+
+  - vulnerability: CVE-2022-30065 # alpine does not yet provide a fixed version (and the default docker image does not use or expose `awk` when running the server)

--- a/contrib/rewrites-example/keto.yaml
+++ b/contrib/rewrites-example/keto.yaml
@@ -1,0 +1,7 @@
+dsn: memory
+
+namespaces:
+  location: file://./namespaces.keto.ts
+
+log:
+  level: trace

--- a/contrib/rewrites-example/lib.ts
+++ b/contrib/rewrites-example/lib.ts
@@ -1,0 +1,18 @@
+/// <reference no-default-lib="true"/>
+
+type Context = { subject: never }
+
+interface Namespace {
+  related?: { [relation: string]: Namespace[] }
+  permits?: { [method: string]: (ctx: Context) => boolean }
+}
+
+interface Array<Namespace> {
+  includes(element: Namespace): boolean
+  traverse(iteratorfn: (element: Namespace) => boolean): boolean
+}
+
+type SubjectSet<
+  A extends Namespace,
+  R extends keyof A["related"],
+> = A["related"][R] extends Array<infer T> ? T : never

--- a/contrib/rewrites-example/namespaces.keto.ts
+++ b/contrib/rewrites-example/namespaces.keto.ts
@@ -1,0 +1,44 @@
+/// <reference path="./lib.ts" />
+
+class User implements Namespace {
+  related: {
+    manager: User[]
+  }
+}
+
+class Group implements Namespace {
+  related: {
+    members: (User | Group)[]
+  }
+}
+
+class Folder implements Namespace {
+  related: {
+    parents: (File | Folder)[]
+    viewers: SubjectSet<Group, "members">[]
+  }
+
+  permits = {
+    view: (ctx: Context): boolean =>
+      this.related.viewers.includes(ctx.subject) ||
+      this.related.parents.traverse((p) => p.permits.view(ctx)),
+  }
+}
+
+class File implements Namespace {
+  related: {
+    parents: (File | Folder)[]
+    viewers: (User | SubjectSet<Group, "members">)[]
+    owners: (User | SubjectSet<Group, "members">)[]
+  }
+
+  // Some comment
+  permits = {
+    view: (ctx: Context): boolean =>
+      this.related.parents.traverse((p) => p.permits.view(ctx)) ||
+      this.related.viewers.includes(ctx.subject) ||
+      this.related.owners.includes(ctx.subject),
+
+    edit: (ctx: Context) => this.related.owners.includes(ctx.subject),
+  }
+}

--- a/contrib/rewrites-example/relation-tuples/tuples.json
+++ b/contrib/rewrites-example/relation-tuples/tuples.json
@@ -1,0 +1,72 @@
+[
+  {
+    "namespace": "Group",
+    "object": "developer",
+    "relation": "members",
+    "subject_id": "patrik"
+  },
+  {
+    "namespace": "Group",
+    "object": "developer",
+    "relation": "members",
+    "subject_set": {
+      "namespace": "User",
+      "object": "Patrik"
+    }
+  },
+  {
+    "namespace": "Group",
+    "object": "developer",
+    "relation": "members",
+    "subject_set": {
+      "namespace": "User",
+      "object": "Henning"
+    }
+  },
+  {
+    "namespace": "Folder",
+    "object": "keto/",
+    "relation": "viewers",
+    "subject_set": {
+      "namespace": "Group",
+      "object": "developer",
+      "relation": "members"
+    }
+  },
+  {
+    "namespace": "File",
+    "object": "keto/README.md",
+    "relation": "parents",
+    "subject_set": {
+      "namespace": "Folder",
+      "object": "keto/"
+    }
+  },
+  {
+    "namespace": "Folder",
+    "object": "keto/src/",
+    "relation": "parents",
+    "subject_set": {
+      "namespace": "Folder",
+      "object": "keto/"
+    }
+  },
+  {
+    "namespace": "File",
+    "object": "keto/src/main.go",
+    "relation": "parents",
+    "subject_set": {
+      "namespace": "Folder",
+      "object": "keto/src/"
+    }
+  },
+  {
+    "namespace": "File",
+    "object": "private",
+    "relation": "owners",
+    "subject_set": {
+      "namespace": "User",
+      "object": "Henning"
+    }
+  }
+]

--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -29,7 +29,7 @@
         }
       },
       "additionalProperties": false,
-      "required": ["name", "id"]
+      "required": ["name"]
     },
     "tlsxSource": {
       "type": "object",
@@ -287,16 +287,35 @@
       "default": "file://./keto_namespaces",
       "oneOf": [
         {
-          "title": "Namespace Repo URI",
-          "description": "URI that points to a directory of namespace files, a single file with all namespaces, or a websocket connection that provides former via `github.com/ory/x/watcherx.WatchAndServeWS`",
+          "title": "Legacy namespace Repo URI",
+          "description": "A URI that points to a directory of namespace files, a single file with all namespaces, or a websocket connection that provides former via `github.com/ory/x/watcherx.WatchAndServeWS`",
           "type": "string",
           "format": "uri"
         },
         {
           "type": "array",
+          "title": "Legacy namespace configuration",
           "items": {
             "$ref": "#/definitions/namespace"
           }
+        },
+        {
+          "type": "object",
+          "title": "Namespace configuration",
+          "properties": {
+            "location": {
+              "type": "string",
+              "title": "Ory Permission Language config file URI",
+              "description": "A URI that points to a directory of namespace files, a single file with all namespaces, or a websocket connection that provides former via `github.com/ory/x/watcherx.WatchAndServeWS`",
+              "format": "uri",
+              "examples": [
+                "file://./keto_namespaces.ts",
+                "file:///etc/configs/keto_namespaces.ts",
+                "ws://my.websocket.server/keto_namespaces.ts"
+              ]
+            }
+          },
+          "required": ["location"]
         }
       ]
     },

--- a/internal/check/engine.go
+++ b/internal/check/engine.go
@@ -121,7 +121,7 @@ func (e *Engine) checkExpandSubject(r *relationTuple, restDepth int) checkgroup.
 					continue
 				}
 				subjectSet, ok := s.Subject.(*relationtuple.SubjectSet)
-				if !ok || subjectSet.Relation == WildcardRelation || subjectSet.Relation == "" {
+				if !ok || subjectSet.Relation == "" {
 					continue
 				}
 				g.Add(e.checkIsAllowed(
@@ -209,7 +209,7 @@ func (e *Engine) checkIsAllowed(ctx context.Context, r *relationTuple, restDepth
 func (e *Engine) astRelationFor(ctx context.Context, r *relationTuple) (*ast.Relation, error) {
 	// Special case: If the relationTuple's relation is empty, then it is not an
 	// error that the relation was not found.
-	if r.Relation == WildcardRelation || r.Relation == "" {
+	if r.Relation == "" {
 		return nil, nil
 	}
 

--- a/internal/check/engine.go
+++ b/internal/check/engine.go
@@ -121,7 +121,7 @@ func (e *Engine) checkExpandSubject(r *relationTuple, restDepth int) checkgroup.
 					continue
 				}
 				subjectSet, ok := s.Subject.(*relationtuple.SubjectSet)
-				if !ok || subjectSet.Relation == WildcardRelation {
+				if !ok || subjectSet.Relation == WildcardRelation || subjectSet.Relation == "" {
 					continue
 				}
 				g.Add(e.checkIsAllowed(
@@ -207,6 +207,12 @@ func (e *Engine) checkIsAllowed(ctx context.Context, r *relationTuple, restDepth
 }
 
 func (e *Engine) astRelationFor(ctx context.Context, r *relationTuple) (*ast.Relation, error) {
+	// Special case: If the relationTuple's relation is empty, then it is not an
+	// error that the relation was not found.
+	if r.Relation == WildcardRelation || r.Relation == "" {
+		return nil, nil
+	}
+
 	ns, err := e.namespaceFor(ctx, r)
 	if err != nil {
 		// On an unknown namespace the answer should be "not allowed", not "not

--- a/internal/check/rewrites_test.go
+++ b/internal/check/rewrites_test.go
@@ -104,15 +104,17 @@ func TestUsersetRewrites(t *testing.T) {
 	reg.Logger().Logger.SetLevel(logrus.TraceLevel)
 
 	insertFixtures(t, reg.RelationTupleManager(), []string{
-		"doc:document#owner@users:user#...",       // user owns doc
-		"doc:doc_in_folder#parent@doc:folder#...", // doc_in_folder is in folder
-		"doc:folder#owner@users:user#...",         // user owns folder
+		"doc:document#owner@plain_user",       // user owns doc
+		"doc:document#owner@users:user",       // user owns doc
+		"doc:doc_in_folder#parent@doc:folder", // doc_in_folder is in folder
+		"doc:folder#owner@plain_user",         // user owns folder
+		"doc:folder#owner@users:user",         // user owns folder
 
 		// Folder hierarchy folder_a -> folder_b -> folder_c -> file
 		// and folder_a is owned by user. Then user should have access to file.
-		"doc:file#parent@doc:folder_c#",
-		"doc:folder_c#parent@doc:folder_b#",
-		"doc:folder_b#parent@doc:folder_a#",
+		"doc:file#parent@doc:folder_c",
+		"doc:folder_c#parent@doc:folder_b",
+		"doc:folder_b#parent@doc:folder_a",
 		"doc:folder_a#owner@user",
 
 		"group:editors#member@mark",
@@ -140,31 +142,32 @@ func TestUsersetRewrites(t *testing.T) {
 		},
 	}, {
 		// userset rewrite
-		query: "doc:document#editor@users:user#...",
+		query: "doc:document#editor@users:user",
 		expected: checkgroup.Result{
 			Membership: checkgroup.IsMember,
 		},
 	}, {
+		// userset rewrite
+		query:    "doc:document#editor@plain_user",
+		expected: checkgroup.ResultIsMember,
+	}, {
 		// transitive userset rewrite
-		query: "doc:document#viewer@users:user#",
-		// expected: checkgroup.ResultIsMember,
-		expected: checkgroup.Result{
-			Membership: checkgroup.IsMember,
-		},
+		query:    "doc:document#viewer@users:user",
+		expected: checkgroup.ResultIsMember,
 	}, {
 		query:    "doc:document#editor@nobody",
 		expected: checkgroup.ResultNotMember,
 	}, {
-		query: "doc:folder#viewer@user",
-		expected: checkgroup.Result{
-			Membership: checkgroup.IsMember,
-		},
+		query:    "doc:folder#viewer@users:user",
+		expected: checkgroup.ResultIsMember,
 	}, {
 		// tuple to userset
-		query: "doc:doc_in_folder#viewer@user",
-		expected: checkgroup.Result{
-			Membership: checkgroup.IsMember,
-		},
+		query:    "doc:doc_in_folder#viewer@users:user",
+		expected: checkgroup.ResultIsMember,
+	}, {
+		// tuple to userset
+		query:    "doc:doc_in_folder#viewer@plain_user",
+		expected: checkgroup.ResultIsMember,
 	}, {
 		// tuple to userset
 		query:    "doc:doc_in_folder#viewer@nobody",

--- a/internal/check/rewrites_test.go
+++ b/internal/check/rewrites_test.go
@@ -37,6 +37,7 @@ var namespaces = []*namespace.Namespace{
 							Relation:                   "parent",
 							ComputedSubjectSetRelation: "viewer"}}}},
 		}},
+	{Name: "users"},
 	{Name: "group",
 		Relations: []ast.Relation{{Name: "member"}},
 	},
@@ -103,9 +104,9 @@ func TestUsersetRewrites(t *testing.T) {
 	reg.Logger().Logger.SetLevel(logrus.TraceLevel)
 
 	insertFixtures(t, reg.RelationTupleManager(), []string{
-		"doc:document#owner@user",              // user owns doc
-		"doc:doc_in_folder#parent@doc:folder#", // doc_in_folder is in folder
-		"doc:folder#owner@user",                // user owns folder
+		"doc:document#owner@users:user#...",       // user owns doc
+		"doc:doc_in_folder#parent@doc:folder#...", // doc_in_folder is in folder
+		"doc:folder#owner@users:user#...",         // user owns folder
 
 		// Folder hierarchy folder_a -> folder_b -> folder_c -> file
 		// and folder_a is owned by user. Then user should have access to file.
@@ -133,19 +134,20 @@ func TestUsersetRewrites(t *testing.T) {
 		expectedPaths []path
 	}{{
 		// direct
-		query: "doc:document#owner@user",
+		query: "doc:document#owner@users:user",
 		expected: checkgroup.Result{
 			Membership: checkgroup.IsMember,
 		},
 	}, {
 		// userset rewrite
-		query: "doc:document#editor@user",
+		query: "doc:document#editor@users:user#...",
 		expected: checkgroup.Result{
 			Membership: checkgroup.IsMember,
 		},
 	}, {
 		// transitive userset rewrite
-		query: "doc:document#viewer@user",
+		query: "doc:document#viewer@users:user#",
+		// expected: checkgroup.ResultIsMember,
 		expected: checkgroup.Result{
 			Membership: checkgroup.IsMember,
 		},

--- a/internal/check/rewrites_test.go
+++ b/internal/check/rewrites_test.go
@@ -103,22 +103,22 @@ func TestUsersetRewrites(t *testing.T) {
 	reg.Logger().Logger.SetLevel(logrus.TraceLevel)
 
 	insertFixtures(t, reg.RelationTupleManager(), []string{
-		"doc:document#owner@user",                 // user owns doc
-		"doc:doc_in_folder#parent@doc:folder#...", // doc_in_folder is in folder
-		"doc:folder#owner@user",                   // user owns folder
+		"doc:document#owner@user",              // user owns doc
+		"doc:doc_in_folder#parent@doc:folder#", // doc_in_folder is in folder
+		"doc:folder#owner@user",                // user owns folder
 
 		// Folder hierarchy folder_a -> folder_b -> folder_c -> file
 		// and folder_a is owned by user. Then user should have access to file.
-		"doc:file#parent@doc:folder_c#...",
-		"doc:folder_c#parent@doc:folder_b#...",
-		"doc:folder_b#parent@doc:folder_a#...",
+		"doc:file#parent@doc:folder_c#",
+		"doc:folder_c#parent@doc:folder_b#",
+		"doc:folder_b#parent@doc:folder_a#",
 		"doc:folder_a#owner@user",
 
 		"group:editors#member@mark",
 		"level:superadmin#member@mark",
 		"level:superadmin#member@sandy",
-		"resource:topsecret#owner@group:editors#...",
-		"resource:topsecret#level@level:superadmin#...",
+		"resource:topsecret#owner@group:editors#",
+		"resource:topsecret#level@level:superadmin#",
 		"resource:topsecret#owner@mike",
 
 		"acl:document#allow@alice",

--- a/internal/driver/config/opl_config_namespace_watcher.go
+++ b/internal/driver/config/opl_config_namespace_watcher.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/ory/x/logrusx"
+	"github.com/ory/x/watcherx"
+
+	"github.com/ory/keto/internal/namespace"
+	"github.com/ory/keto/internal/schema"
+)
+
+type (
+	configFiles struct {
+		byPath map[string]io.Reader
+		sync.Mutex
+	}
+
+	oplConfigWatcher struct {
+		logger *logrusx.Logger
+		target string
+		files  configFiles
+
+		memoryNamespaceManager
+	}
+)
+
+var _ namespace.Manager = (*oplConfigWatcher)(nil)
+
+func newOPLConfigWatcher(ctx context.Context, l *logrusx.Logger, target string) (*oplConfigWatcher, error) {
+
+	nw := &oplConfigWatcher{
+		logger:                 l,
+		target:                 target,
+		files:                  configFiles{byPath: make(map[string]io.Reader)},
+		memoryNamespaceManager: *NewMemoryNamespaceManager(),
+	}
+
+	return nw, watchTarget(ctx, target, nw, l)
+}
+
+func (nw *oplConfigWatcher) handleChange(e *watcherx.ChangeEvent) {
+	// the lock is acquired before parsing to ensure that the getters are
+	// waiting for the updated values
+	nw.files.Lock()
+	defer nw.files.Unlock()
+	nw.files.byPath[e.Source()] = e.Reader()
+	nw.parseFiles()
+}
+
+func (nw *oplConfigWatcher) handleRemove(e *watcherx.RemoveEvent) {
+	nw.files.Lock()
+	defer nw.files.Unlock()
+	delete(nw.files.byPath, e.Source())
+	nw.parseFiles()
+}
+
+func (nw *oplConfigWatcher) handleError(e *watcherx.ErrorEvent) {
+	nw.logger.
+		WithError(e).
+		Errorf("Received error while watching OPL config files at target %s.",
+			nw.target)
+}
+
+// parseFiles loops through all files, parsing each and getting the namespaces.
+// It then sets the namespaces only if there were no errors.
+//
+// The caller must  hold the lock to nw.files.
+func (nw *oplConfigWatcher) parseFiles() {
+	var (
+		namespaces = make([]*namespace.Namespace, 0)
+		errs       []error
+	)
+	for _, reader := range nw.files.byPath {
+		content, err := io.ReadAll(reader)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		nn, ee := schema.Parse(string(content))
+		errs = append(errs, ee...)
+		for _, n := range nn {
+			n := n // alias because we want a reference
+			namespaces = append(namespaces, &n)
+		}
+	}
+	if len(errs) > 0 {
+		for _, err := range errs {
+			nw.logger.
+				WithError(err).
+				Errorf("Failed to parse OPL config files at target %s.",
+					nw.target)
+		}
+		return
+	}
+	nw.set(namespaces)
+}


### PR DESCRIPTION
The userset rewrites can now be configured through the Ory Permission
Language (OPL), which is a subset of TypeScript. The OPL config is
referenced in the central configuration under namespaces as such:

  [...]
  namespaces:
    config: <location>
  [...]

The <location> can be any valid file, directory or URI.

This is a follow up to expose the features implemented in #877 
