### PR TITLE
fix(cli): distinguish between subjectSet and subjectID in check command

### DIFF
--- a/internal/e2e/cases_test.go
+++ b/internal/e2e/cases_test.go
@@ -28,6 +28,33 @@ func runCases(c client, m *namespaceTestManager) func(*testing.T) {
 			assert.Len(t, resp.RelationTuples, 0)
 		})
 
+		t.Run("case=check subjectSet relations", func(t *testing.T) {
+			n := &namespace.Namespace{Name: t.Name()}
+			m.add(t, n)
+
+			obj := fmt.Sprintf("tree for client %T", c)
+			rel := "expand"
+
+			ss := &ketoapi.SubjectSet{
+				Namespace: n.Name,
+				Object:    obj,
+				Relation:  rel,
+			}
+			c.createTuple(t, &ketoapi.RelationTuple{
+				Namespace:  n.Name,
+				Object:     obj,
+				Relation:   rel,
+				SubjectSet: ss,
+			})
+			rt := &ketoapi.RelationTuple{
+				Namespace:  n.Name,
+				Object:     obj,
+				Relation:   rel,
+				SubjectSet: ss,
+			}
+
+			assert.True(t, c.check(t, rt))
+		})
 		t.Run("case=creates tuple and uses it then", func(t *testing.T) {
 			n := &namespace.Namespace{Name: t.Name()}
 			m.add(t, n)


### PR DESCRIPTION
attempt of fixing #850 but the command:

`./keto check 'videos:/cats/1.mp4#owner' view videos '/cats/1.mp4'`
still Outputs "Denied" even though it should be "Allowed" because of:
```
NAMESPACE       OBJECT          RELATION NAME   SUBJECT
videos          /cats/1.mp4     view            videos:/cats/1.mp4#owner

```