### PR TITLE
fix(deps): error obtaining VCS status: exit status 128 at docker build

### DIFF
--- a/.docker/Dockerfile-build
+++ b/.docker/Dockerfile-build
@@ -16,7 +16,7 @@ RUN go mod download
 
 ADD . .
 
-RUN go build -tags sqlite -o /usr/bin/keto .
+RUN go build -buildvcs=false -tags sqlite -o /usr/bin/keto .
 
 FROM alpine:3.16
 


### PR DESCRIPTION
How to replicate the error: `make docker`

Previous error:
```
... long log
 ---> f394d136bb6c
Step 7/24 : ADD proto/go.sum proto/go.sum
 ---> 7fca7e520cb3
Step 8/24 : ENV CGO_ENABLED 1
 ---> Running in ca87bf346155
Removing intermediate container ca87bf346155
 ---> af2dbef0c762
Step 9/24 : RUN go mod download
 ---> Running in 98785997fa9c
Removing intermediate container 98785997fa9c
 ---> f74577fb6d14
Step 10/24 : ADD . .
 ---> f1cc0ac767f0
Step 11/24 : RUN go build -tags sqlite -o /usr/bin/keto .
 ---> Running in 913258959d81
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
The command '/bin/sh -c go build -tags sqlite -o /usr/bin/keto .'
returned a non-zero code: 1
```

This is fixed by setting `-buildvcs=false` flag

ref: https://github.com/golang/go/issues/49004

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security. vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added or changed [the documentation](https://github.com/ory/docs).
