### PR TITLE
fix: uuid mapping migration paginates

### DIFF
--- a/internal/persistence/sql/migrations/uuidmapping/uuid_mapping_migrator.go
+++ b/internal/persistence/sql/migrations/uuidmapping/uuid_mapping_migrator.go
@@ -188,7 +188,6 @@ var (
 				Runner: func(_ popx.Migration, conn *pop.Connection, _ *pop.Tx) error {
 					var (
 						relationTuples []OldRelationTuple
-						offset         int
 						err            error
 						lastID         uuid.UUID
 					)
@@ -216,9 +215,6 @@ var (
 						}
 						if err := BatchInsertTuples(conn, newTuples); err != nil {
 							return fmt.Errorf("could not insert new tuples: %w", err)
-						}
-						if offset == 0 {
-							break
 						}
 					}
 


### PR DESCRIPTION
Before the migration finished after the first page and ignored the rest of the table. This is now fixed and the whole table is migrated. Also a test was added to verify this works.