### PR TITLE
chore: remove double tabs from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endef
 $(foreach dep, $(GO_DEPENDENCIES), $(eval $(call make-go-dependency,$(dep),$(notdir $(dep)))))
 
 tools/yq: .bin/gobin/go.mod .bin/gobin/go.sum Makefile
-		cd .bin/gobin; GOBIN=$(PWD)/.bin/gobin go install github.com/mikefarah/yq/v4
+	cd .bin/gobin; GOBIN=$(PWD)/.bin/gobin go install github.com/mikefarah/yq/v4
 
 define make-brew-dependency
   tools/$(firstword $(subst @, ,$(notdir $1))): tools/brew Makefile
@@ -37,86 +37,86 @@ endef
 $(foreach dep, $(BREW_DEPENDENCIES), $(eval $(call make-brew-dependency,$(dep))))
 
 tools/protobuf: tools/brew Makefile
-		HOMEBREW_NO_AUTO_UPDATE=1 brew install protobuf@3.19
+	HOMEBREW_NO_AUTO_UPDATE=1 brew install protobuf@3.19
 
 node_modules: package-lock.json
-		npm ci
-		touch node_modules
+	npm ci
+	touch node_modules
 
 .PHONY: tools/brew
 tools/brew:
-		./scripts/install-brew.sh
+	./scripts/install-brew.sh
 
 # this is not using the tools/* prefix, as a github action has hardcoded paths for this
 .PHONY: .bin/clidoc
 .bin/clidoc:
-		go build -o .bin/clidoc ./cmd/clidoc/.
+	go build -o .bin/clidoc ./cmd/clidoc/.
 
 .PHONY: format
 format: tools/goimports node_modules
-		goimports -w -local github.com/ory/keto *.go internal cmd contrib ketoctx ketoapi embedx
-		npm exec -- prettier --write .
+	goimports -w -local github.com/ory/keto *.go internal cmd contrib ketoctx ketoapi embedx
+	npm exec -- prettier --write .
 
 .PHONY: install
 install:
-		go install -tags sqlite .
+	go install -tags sqlite .
 
 .PHONY: docker
 docker:
-		docker build -t oryd/keto:latest -f .docker/Dockerfile-build .
+	docker build -t oryd/keto:latest -f .docker/Dockerfile-build .
 
 # Generates the SDKs
 .PHONY: sdk
 sdk: tools/go-swagger tools/cli node_modules
-		rm -rf internal/httpclient
-		swagger generate spec -m -o spec/swagger.json \
-			-c github.com/ory/keto \
-			-c github.com/ory/x/healthx \
-			-x internal/httpclient \
-			-x internal/e2e
-		ory dev swagger sanitize ./spec/swagger.json
-		swagger validate ./spec/swagger.json
-		CIRCLE_PROJECT_USERNAME=ory CIRCLE_PROJECT_REPONAME=keto \
-				ory dev openapi migrate \
-					--health-path-tags metadata \
-					-p https://raw.githubusercontent.com/ory/x/master/healthx/openapi/patch.yaml \
-					-p file://.schema/openapi/patches/meta.yaml \
-					spec/swagger.json spec/api.json
+	rm -rf internal/httpclient
+	swagger generate spec -m -o spec/swagger.json \
+		-c github.com/ory/keto \
+		-c github.com/ory/x/healthx \
+		-x internal/httpclient \
+		-x internal/e2e
+	ory dev swagger sanitize ./spec/swagger.json
+	swagger validate ./spec/swagger.json
+	CIRCLE_PROJECT_USERNAME=ory CIRCLE_PROJECT_REPONAME=keto \
+		ory dev openapi migrate \
+			--health-path-tags metadata \
+			-p https://raw.githubusercontent.com/ory/x/master/healthx/openapi/patch.yaml \
+			-p file://.schema/openapi/patches/meta.yaml \
+			spec/swagger.json spec/api.json
 
-		mkdir -p internal/httpclient
+	mkdir -p internal/httpclient
 
-		npm run openapi-generator-cli -- generate -i "spec/api.json" \
-				-g go \
-				-o "internal/httpclient" \
-				--git-user-id ory \
-				--git-repo-id keto-client-go \
-				--git-host github.com \
-				-t .schema/openapi/templates/go \
-				-c .schema/openapi/gen.go.yml
+	npm run openapi-generator-cli -- generate -i "spec/api.json" \
+		-g go \
+		-o "internal/httpclient" \
+		--git-user-id ory \
+		--git-repo-id keto-client-go \
+		--git-host github.com \
+		-t .schema/openapi/templates/go \
+		-c .schema/openapi/gen.go.yml
 
-		rm internal/httpclient/go.{mod,sum}
+	rm internal/httpclient/go.{mod,sum}
 
-		make format
+	make format
 
 .PHONY: build
 build:
-		go build -tags sqlite
+	go build -tags sqlite
 
 #
 # Generate APIs and client stubs from the definitions
 #
 .PHONY: buf-gen
 buf-gen: tools/buf tools/protobuf tools/protoc-gen-go tools/protoc-gen-go-grpc tools/protoc-gen-doc node_modules
-		buf generate
-		@echo "All code was generated successfully!"
+	buf generate
+	@echo "All code was generated successfully!"
 
 #
 # Lint API definitions
 #
 .PHONY: buf-lint
 buf-lint: tools/buf
-		buf lint
-		@echo "All lint checks passed successfully!"
+	buf lint
+	@echo "All lint checks passed successfully!"
 
 #
 # Generate after linting succeeded
@@ -126,37 +126,37 @@ buf: buf-lint buf-gen
 
 .PHONY: test-e2e
 test-e2e:
-		go test -tags sqlite -failfast -v ./internal/e2e
+	go test -tags sqlite -failfast -v ./internal/e2e
 
 .PHONY: test-docs-samples
 test-docs-samples: tools/jd
-		cd ./contrib/docs-code-samples \
-		&& \
-		npm i \
-		&& \
-		npm test
+	cd ./contrib/docs-code-samples \
+	&& \
+	npm i \
+	&& \
+	npm test
 
 .PHONY: fuzz-test
 fuzz-test:
-		go test -tags=sqlite -fuzz=FuzzParser -fuzztime=10s ./internal/schema
+	go test -tags=sqlite -fuzz=FuzzParser -fuzztime=10s ./internal/schema
 
 .PHONY: libfuzzer-fuzz-test
 libfuzzer-fuzz-test: .bin/go114-fuzz-build
-		mkdir -p .fuzzer
-		.bin/go114-fuzz-build -o ./.fuzzer/parser.a ./internal/schema
-		clang -fsanitize=fuzzer ./.fuzzer/parser.a -o ./.fuzzer/parser
-		./.fuzzer/parser -timeout=1 -max_total_time=10 -use_value_profile
+	mkdir -p .fuzzer
+	.bin/go114-fuzz-build -o ./.fuzzer/parser.a ./internal/schema
+	clang -fsanitize=fuzzer ./.fuzzer/parser.a -o ./.fuzzer/parser
+	./.fuzzer/parser -timeout=1 -max_total_time=10 -use_value_profile
 
 .PHONY: cve-scan
 cve-scan: docker tools/grype
-		grype oryd/keto:latest
+	grype oryd/keto:latest
 
 .PHONY: post-release
 post-release: tools/yq
-		cat docker-compose.yml | yq '.services.keto.image = "oryd/keto:'$$DOCKER_TAG'"' | sponge docker-compose.yml
-		cat docker-compose-mysql.yml | yq '.services.keto-migrate.image = "oryd/keto:'$$DOCKER_TAG'"' | sponge docker-compose-mysql.yml
-		cat docker-compose-postgres.yml | yq '.services.keto-migrate.image = "oryd/keto:'$$DOCKER_TAG'"' | sponge docker-compose-postgres.yml
+	cat docker-compose.yml | yq '.services.keto.image = "oryd/keto:'$$DOCKER_TAG'"' | sponge docker-compose.yml
+	cat docker-compose-mysql.yml | yq '.services.keto-migrate.image = "oryd/keto:'$$DOCKER_TAG'"' | sponge docker-compose-mysql.yml
+	cat docker-compose-postgres.yml | yq '.services.keto-migrate.image = "oryd/keto:'$$DOCKER_TAG'"' | sponge docker-compose-postgres.yml
 
 .PHONY: generate
 generate: tools/stringer
-		go generate ./...
+	go generate ./...


### PR DESCRIPTION
Reduces the indentation of Makefiles from double tabs to single tabs.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).
