### PR TITLE
docs: adds JSDoc to the npm package '@ory/keto-namespace-types'

### DIFF
--- a/contrib/namespace-type-lib/index.d.ts
+++ b/contrib/namespace-type-lib/index.d.ts
@@ -13,7 +13,7 @@ declare interface RegExp {}
 
 declare interface Array<T extends namespace> {
   /**
-   * Checks weather the elements of this Array have a Relation to the given Subject
+   * Checks whether the elements of this Array have a Relation to the given Subject
    * @example
    * class File implements Namespace {
    *   related: {
@@ -29,7 +29,7 @@ declare interface Array<T extends namespace> {
   includes(element: T): boolean
 
   /**
-   * Executes the {@link iteratorfn} on every element in the Array.
+   * Executes the {@link iteratorfn} on every element in the Array and evaluates to true if {@link iteratorfn} returns true for any element.
    *
    * @example
    * class File implements Namespace {
@@ -39,7 +39,7 @@ declare interface Array<T extends namespace> {
    *
    *   permits = {
    *     view: (ctx: Context): boolean =>
-   *        // Checks weather the given context (e.g. subject) has view permissions on any of the parents,
+   *        // Checks whether the given context (e.g. subject) has view permissions on any of the parents,
    *        // effectively inhertiting the view permissions of the parents
    *       this.related.parents.traverse((p) => p.permits.view(ctx))
    *   }

--- a/contrib/namespace-type-lib/index.d.ts
+++ b/contrib/namespace-type-lib/index.d.ts
@@ -12,7 +12,41 @@ declare interface IArguments {}
 declare interface RegExp {}
 
 declare interface Array<T extends namespace> {
+  /**
+   * Checks weather the elements of this Array have a Relation to the given Subject
+   * @example
+   * class File implements Namespace {
+   *   related: {
+   *     owners: (User | SubjectSet<Group, "members">)[]
+   *   }
+   *
+   *   permits = {
+   *     edit: (ctx: Context) => this.related.owners.includes(ctx.subject),
+   *   }
+   * }
+   * @param element usually `ctx.subject`
+   */
   includes(element: T): boolean
+
+  /**
+   * Executes the {@link iteratorfn} on every element in the Array.
+   *
+   * @example
+   * class File implements Namespace {
+   *   related: {
+   *     parents: (File | Folder)[]
+   *   }
+   *
+   *   permits = {
+   *     view: (ctx: Context): boolean =>
+   *        // Checks weather the given context (e.g. subject) has view permissions on any of the parents,
+   *        // effectively inhertiting the view permissions of the parents
+   *       this.related.parents.traverse((p) => p.permits.view(ctx))
+   *   }
+   * }
+   *
+   * @param iteratorfn The function that checks if a connection exits
+   */
   traverse(iteratorfn: (element: T) => boolean): boolean
 }
 
@@ -21,7 +55,14 @@ interface context {
 }
 
 interface namespace {
+  /**
+   * Possible Relations to Objects of Namespaces
+   */
   related?: { [relation: string]: namespace[] }
+
+  /**
+   * Dynamically computed Relations
+   */
   permits?: { [method: string]: (ctx: context) => boolean }
 }
 


### PR DESCRIPTION
Adds JSDoc to the npm package '@ory/keto-namespace-types'.
This will enable displaying what the different methods do in the IDE as documentation

## Related issue(s)

None

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.

Please be aware that pull requests must have all boxes ticked in order to be merged.

If you're unsure about any of them, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] ~~I have added tests that prove my fix is effective or that my feature
      works.~~ (not needed in my opinion)
- [ ] ~~I have added or changed [the documentation](https://github.com/ory/docs).~~ (not needed in my opinion)

## Further Comments

Please give feedback if my understanding of the PermissionLanguage is correct
