### PR TITLE
fix: do not return `nil` on unknown subject set on expand

### DIFF
--- a/internal/expand/engine.go
+++ b/internal/expand/engine.go
@@ -79,10 +79,7 @@ func (e *Engine) BuildTree(ctx context.Context, subject relationtuple.Subject, r
 		if err != nil {
 			return nil, err
 		} else if len(rels) == 0 {
-			return &relationtuple.Tree{
-				Type:    ketoapi.TreeNodeLeaf,
-				Subject: subject,
-			}, nil
+			return nil, nil
 		}
 
 		if restDepth <= 1 {

--- a/internal/expand/engine_test.go
+++ b/internal/expand/engine_test.go
@@ -374,4 +374,20 @@ func TestEngine(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedTree, tree)
 	})
+
+	t.Run("case=returns result on unknown subject", func(t *testing.T) {
+		_, e := newTestEngine(t, []*namespace.Namespace{})
+		subject := &relationtuple.SubjectSet{
+			Namespace: "unknown",
+			Object:    uuid.Must(uuid.NewV4()),
+			Relation:  "rel",
+		}
+
+		tree, err := e.BuildTree(context.Background(), subject, 100)
+		require.NoError(t, err)
+		assert.Equal(t, &relationtuple.Tree{
+			Type:    ketoapi.TreeNodeLeaf,
+			Subject: subject,
+		}, tree)
+	})
 }

--- a/internal/expand/engine_test.go
+++ b/internal/expand/engine_test.go
@@ -377,17 +377,12 @@ func TestEngine(t *testing.T) {
 
 	t.Run("case=returns result on unknown subject", func(t *testing.T) {
 		_, e := newTestEngine(t, []*namespace.Namespace{})
-		subject := &relationtuple.SubjectSet{
+		tree, err := e.BuildTree(context.Background(), &relationtuple.SubjectSet{
 			Namespace: "unknown",
 			Object:    uuid.Must(uuid.NewV4()),
 			Relation:  "rel",
-		}
-
-		tree, err := e.BuildTree(context.Background(), subject, 100)
+		}, 100)
 		require.NoError(t, err)
-		assert.Equal(t, &relationtuple.Tree{
-			Type:    ketoapi.TreeNodeLeaf,
-			Subject: subject,
-		}, tree)
+		assert.Nil(t, tree)
 	})
 }

--- a/internal/expand/handler.go
+++ b/internal/expand/handler.go
@@ -96,6 +96,11 @@ func (h *handler) getExpand(w http.ResponseWriter, r *http.Request, _ httprouter
 		h.d.Writer().WriteError(w, r, err)
 		return
 	}
+	if res == nil {
+		h.d.Writer().Write(w, r, herodot.ErrNotFound.WithError("no relation tuple found"))
+		return
+	}
+
 	tree, err := h.d.Mapper().ToTree(r.Context(), res)
 	if err != nil {
 		h.d.Writer().WriteError(w, r, err)


### PR DESCRIPTION
Unknown subject sets resulted in `nil` being returned, which in turn caused panics in the handler.