### PR TITLE
fix: remove pagination-related query elements on LIMIT 1

### DIFF
--- a/internal/persistence/sql/relationtuples.go
+++ b/internal/persistence/sql/relationtuples.go
@@ -212,10 +212,12 @@ func (p *Persister) GetRelationTuples(ctx context.Context, query *relationtuple.
 		return nil, "", err
 	}
 
-	sqlQuery := p.QueryWithNetwork(ctx).
-		Order("shard_id, nid").
-		Where("shard_id > ?", pagination.LastID).
-		Limit(pagination.PerPage + 1)
+	sqlQuery := p.QueryWithNetwork(ctx).Limit(1)
+	if pagination.PerPage != 1 {
+		sqlQuery = sqlQuery.Order("shard_id, nid").
+			Where("shard_id > ?", pagination.LastID).
+			Limit(pagination.PerPage + 1)
+	}
 
 	err = p.whereQuery(ctx, sqlQuery, query)
 	if err != nil {


### PR DESCRIPTION
This patch removes query components which cause CockroachDB to perform a full-range query across all leaseholders for LIMIT 1 queries. Essentially, CockroachDB will query all potential nodes which might hold data when ORDER BY is used, or when the LIMIT indicates that there are rows missing.

This can drop the query latency to a few ms versus hundreds of ms on a CockroachDB `REGIONAL BY ROW` table, without impact on the business logic.

Closes #1167

## Further Comments

I wasn't quite sure how to write tests for this. One way would be to test the resulting SQL query, but we do not have such capabilities yet.