### PR TITLE
fix: trace SQL in TraverseSubjectSetExpansion

### DIFF
--- a/internal/persistence/sql/traverser.go
+++ b/internal/persistence/sql/traverser.go
@@ -71,7 +71,7 @@ func (t *Traverser) TraverseSubjectSetExpansion(ctx context.Context, start *rela
 			rows  []*subjectExpandedRelationTupleRow
 			limit = 1000
 		)
-		err = t.conn.RawQuery(fmt.Sprintf(`
+		err = t.conn.WithContext(ctx).RawQuery(fmt.Sprintf(`
 SELECT current.shard_id AS shard_id,
        current.subject_set_namespace AS namespace,
        current.subject_set_object AS object,


### PR DESCRIPTION
The SQL traces from this functions are currently missing.