### PR TITLE
fix: return meaningful status code when relation is not known

### DIFF
--- a/internal/namespace/definitions.go
+++ b/internal/namespace/definitions.go
@@ -6,7 +6,8 @@ package namespace
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+
+	"github.com/ory/herodot"
 
 	"github.com/ory/keto/internal/namespace/ast"
 )
@@ -57,5 +58,5 @@ func ASTRelationFor(ctx context.Context, m Manager, namespace, relation string) 
 			return &rel, nil
 		}
 	}
-	return nil, fmt.Errorf("relation %q not found", relation)
+	return nil, herodot.ErrBadRequest.WithReasonf("relation %q does not exist", relation)
 }

--- a/internal/namespace/definitions_test.go
+++ b/internal/namespace/definitions_test.go
@@ -1,0 +1,40 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package namespace_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/ory/herodot"
+	"github.com/ory/x/pointerx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/keto/internal/driver/config"
+	"github.com/ory/keto/internal/namespace"
+	"github.com/ory/keto/internal/namespace/ast"
+)
+
+func TestASTRelationFor(t *testing.T) {
+	ctx := context.Background()
+	nm := config.NewMemoryNamespaceManager(&namespace.Namespace{
+		Name:      "test",
+		Relations: []ast.Relation{{Name: "test"}},
+	})
+
+	rel, err := namespace.ASTRelationFor(ctx, nm, "test", "test")
+	require.NoError(t, err)
+	assert.Equal(t, "test", rel.Name)
+
+	_, err = namespace.ASTRelationFor(ctx, nm, "test", "unknown")
+	herodotErr := herodot.ErrBadRequest
+	require.ErrorAs(t, err, pointerx.Ptr(&herodotErr))
+	assert.Equal(t, http.StatusBadRequest, herodotErr.CodeField)
+
+	rel, err = namespace.ASTRelationFor(ctx, nm, "unknown", "")
+	require.NoError(t, err)
+	assert.Nil(t, rel)
+}


### PR DESCRIPTION
Currently we return `500 - Internal server error`.