### PR TITLE
fix: reduce SQL tracing noise

### DIFF
--- a/internal/driver/pop_connection.go
+++ b/internal/driver/pop_connection.go
@@ -27,6 +27,7 @@ func (r *RegistryDefault) PopConnectionWithOpts(ctx context.Context, popOpts ...
 		InstrumentedDriverOptions: []instrumentedsql.Opt{
 			instrumentedsql.WithTracer(otelsql.NewTracer()),
 			instrumentedsql.WithIncludeArgs(),
+			instrumentedsql.WithOpsExcluded(instrumentedsql.OpSQLRowsNext),
 		},
 	}
 	for _, o := range popOpts {


### PR DESCRIPTION
This can massively reduce noise in traces, without any real loss in information.

Gets rid of these spans:
<img width="768" alt="image" src="https://user-images.githubusercontent.com/3969502/229785623-a6e7b1af-0d26-4752-ab41-8931308705c0.png">
