### PR TITLE
feat: write to UUID mapper and relation tuples in one SQL transaction

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,12 @@ linters:
   enable:
     - gosec
     - goimports
-    - deadcode
     - errcheck
     - gosimple
     - ineffassign
     - staticcheck
     - typecheck
     - unused
-    - varcheck
 
 linters-settings:
   goimports:

--- a/cmd/client/grpc_client.go
+++ b/cmd/client/grpc_client.go
@@ -35,7 +35,7 @@ const (
 
 	EnvReadRemote  = "KETO_READ_REMOTE"
 	EnvWriteRemote = "KETO_WRITE_REMOTE"
-	EnvAuthToken   = "KETO_BEARER_TOKEN" // nosec G101 -- just the key, not the value
+	EnvAuthToken   = "KETO_BEARER_TOKEN" //nolint:gosec // just the key, not the value
 	EnvAuthority   = "KETO_AUTHORITY"
 
 	ContextKeyTimeout contextKeys = "timeout"
@@ -51,7 +51,8 @@ func (d *connectionDetails) dialOptions() (opts []grpc.DialOption) {
 	if d.token != "" {
 		opts = append(opts,
 			grpc.WithPerRPCCredentials(
-				oauth.NewOauthAccess(&oauth2.Token{AccessToken: d.token})))
+				oauth.TokenSource{oauth2.StaticTokenSource(&oauth2.Token{AccessToken: d.token})},
+			))
 	}
 	if d.authority != "" {
 		opts = append(opts, grpc.WithAuthority(d.authority))
@@ -63,7 +64,7 @@ func (d *connectionDetails) dialOptions() (opts []grpc.DialOption) {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	case d.skipHostVerification:
 		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
-			// nolint explicity set through scary flag
+			//nolint:gosec // explicity set through scary flag
 			InsecureSkipVerify: true,
 		})))
 	default:

--- a/doc_swagger.go
+++ b/doc_swagger.go
@@ -10,6 +10,8 @@ import "github.com/ory/herodot"
 // The standard Ory JSON API error format.
 //
 // swagger:model errorGeneric
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type errorGeneric struct {
 	// Contains error details
 	//
@@ -20,5 +22,6 @@ type errorGeneric struct {
 // An empty response
 //
 // swagger:response emptyResponse
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type emptyResponse struct{}

--- a/internal/check/engine_test.go
+++ b/internal/check/engine_test.go
@@ -246,7 +246,7 @@ func TestEngine(t *testing.T) {
 
 		insertFixtures(t, reg.RelationTupleManager(), tuples)
 		e := check.NewEngine(reg)
-		reg.Config(ctx).Set(config.KeyLimitMaxReadDepth, 5)
+		require.NoError(t, reg.Config(ctx).Set(config.KeyLimitMaxReadDepth, 5))
 
 		cases := []struct {
 			tuple string

--- a/internal/check/handler.go
+++ b/internal/check/handler.go
@@ -112,7 +112,8 @@ func (h *Handler) getCheckNoStatus(w http.ResponseWriter, r *http.Request, _ htt
 // Check Permission Or Error Request Parameters
 //
 // swagger:parameters checkPermissionOrError
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type checkPermissionOrError struct {
 	// in: query
 	MaxDepth int `json:"max-depth"`
@@ -177,7 +178,8 @@ func (h *Handler) getCheck(ctx context.Context, q url.Values) (bool, error) {
 // Check Permission using Post Request Parameters
 //
 // swagger:parameters postCheckPermission
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type postCheckPermission struct {
 	// in: query
 	MaxDepth int `json:"max-depth"`
@@ -189,7 +191,8 @@ type postCheckPermission struct {
 // Check Permission using Post Request Body
 //
 // swagger:model postCheckPermissionBody
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type postCheckPermissionBody struct {
 	ketoapi.RelationQuery
 }
@@ -224,9 +227,9 @@ func (h *Handler) postCheckNoStatus(w http.ResponseWriter, r *http.Request, _ ht
 // Post Check Permission Or Error Request Parameters
 //
 // swagger:parameters postCheckPermissionOrError
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type postCheckPermissionOrError struct {
-	// nolint:deadcode,unused
 	// in: query
 	MaxDepth int `json:"max-depth"`
 
@@ -237,7 +240,8 @@ type postCheckPermissionOrError struct {
 // Post Check Permission Or Error Body
 //
 // swagger:model postCheckPermissionOrErrorBody
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type postCheckPermissionOrErrorBody struct {
 	ketoapi.RelationQuery
 }

--- a/internal/driver/config/namespace_memory.go
+++ b/internal/driver/config/namespace_memory.go
@@ -45,7 +45,9 @@ func (s *memoryNamespaceManager) GetNamespaceByConfigID(_ context.Context, id in
 	defer s.RUnlock()
 
 	for _, n := range s.byName {
-		if n.ID == id { // nolint ignore deprecated method
+		//lint:ignore SA1019 backwards compatibility
+		//nolint:staticcheck
+		if n.ID == id {
 			return n, nil
 		}
 	}

--- a/internal/driver/config/namespace_watcher.go
+++ b/internal/driver/config/namespace_watcher.go
@@ -229,7 +229,9 @@ func (nw *NamespaceWatcher) GetNamespaceByConfigID(_ context.Context, id int32) 
 	defer nw.RUnlock()
 
 	for _, nspace := range nw.namespaces {
-		if nspace.namespace.ID == id { // nolint ignore deprecated ID
+		//lint:ignore SA1019 backwards compatibility
+		//nolint:staticcheck
+		if nspace.namespace.ID == id {
 			return nspace.namespace, nil
 		}
 	}

--- a/internal/driver/daemon.go
+++ b/internal/driver/daemon.go
@@ -187,7 +187,7 @@ func (r *RegistryDefault) serveOPLSyntax(ctx context.Context, done chan<- struct
 func (r *RegistryDefault) serveMetrics(ctx context.Context, done chan<- struct{}) func() error {
 	ctx, cancel := context.WithCancel(ctx)
 
-	// nolint: gosec,G112 graceful.WithDefaults already sets a timeout
+	//nolint:gosec // graceful.WithDefaults already sets a timeout
 	s := graceful.WithDefaults(&http.Server{
 		Handler: r.metricsRouter(ctx),
 		Addr:    r.Config(ctx).MetricsListenOn(),
@@ -237,7 +237,7 @@ func multiplexPort(ctx context.Context, log *logrusx.Logger, addr string, router
 	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpL := m.Match(cmux.HTTP1())
 
-	// nolint: gosec,G112 graceful.WithDefaults already sets a timeout
+	//nolint:gosec // graceful.WithDefaults already sets a timeout
 	restS := graceful.WithDefaults(&http.Server{
 		Handler: router,
 	})

--- a/internal/driver/registry_default.go
+++ b/internal/driver/registry_default.go
@@ -344,3 +344,11 @@ func (r *RegistryDefault) Init(ctx context.Context) (err error) {
 	})
 	return
 }
+
+var _ x.TransactorProvider = (*RegistryDefault)(nil)
+
+func (r *RegistryDefault) Transactor() interface {
+	Transaction(ctx context.Context, f func(ctx context.Context) error) error
+} {
+	return r.Persister()
+}

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -176,12 +176,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/inline_response_200'
           description: Ory Keto is ready to accept connections.
-        "500":
+        default:
           content:
-            application/json:
+            text/plain:
               schema:
-                $ref: '#/components/schemas/genericError'
-          description: genericError
+                type: string
+          description: Unexpected error
       summary: Check HTTP Server Status
       tags:
       - metadata
@@ -210,6 +210,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/inline_response_503'
           description: Ory Kratos is not yet ready to accept requests.
+        default:
+          content:
+            text/plain:
+              schema:
+                type: string
+          description: Unexpected error
       summary: Check HTTP Server and Database Status
       tags:
       - metadata
@@ -1145,6 +1151,8 @@ components:
       - object
       - relation
       type: object
+    unexpectedError:
+      type: string
     version:
       properties:
         version:

--- a/internal/httpclient/api_metadata.go
+++ b/internal/httpclient/api_metadata.go
@@ -264,7 +264,7 @@ func (a *MetadataApiService) IsAliveExecute(r MetadataApiApiIsAliveRequest) (*In
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
+	localVarHTTPHeaderAccepts := []string{"application/json", "text/plain"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -293,15 +293,13 @@ func (a *MetadataApiService) IsAliveExecute(r MetadataApiApiIsAliveRequest) (*In
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
-		if localVarHTTPResponse.StatusCode == 500 {
-			var v GenericError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
-			}
-			newErr.model = v
+		var v string
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			newErr.error = err.Error()
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		newErr.model = v
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
@@ -382,7 +380,7 @@ func (a *MetadataApiService) IsReadyExecute(r MetadataApiApiIsReadyRequest) (*In
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
+	localVarHTTPHeaderAccepts := []string{"application/json", "text/plain"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -419,7 +417,15 @@ func (a *MetadataApiService) IsReadyExecute(r MetadataApiApiIsReadyRequest) (*In
 				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		var v string
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			newErr.error = err.Error()
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		newErr.model = v
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 

--- a/internal/httpclient/docs/MetadataApi.md
+++ b/internal/httpclient/docs/MetadataApi.md
@@ -125,7 +125,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)
@@ -186,7 +186,7 @@ No authorization required
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: application/json, text/plain
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/internal/persistence/definitions.go
+++ b/internal/persistence/definitions.go
@@ -22,6 +22,7 @@ type (
 
 		Connection(ctx context.Context) *pop.Connection
 		NetworkID(ctx context.Context) uuid.UUID
+		Transaction(ctx context.Context, f func(ctx context.Context) error) error
 	}
 	Migrator interface {
 		MigrationBox(ctx context.Context) (*popx.MigrationBox, error)

--- a/internal/persistence/sql/migrations/migratest/migration_test.go
+++ b/internal/persistence/sql/migrations/migratest/migration_test.go
@@ -158,7 +158,8 @@ func TestMigrations(t *testing.T) {
 					var oldRTs []*tuplesBeforeUUID
 					require.NoError(t, p.Connection(ctx).
 						Select("subject_id", "object").
-						// lint:ignore SA1019
+						//lint:ignore SA1019 backwards compatibility
+						//nolint:staticcheck
 						Where("namespace_id = ?", namespaces[1].ID).
 						All(&oldRTs))
 					assert.Equalf(t, "user", oldRTs[0].SubjectID.String, "%+v", oldRTs[0])
@@ -180,7 +181,8 @@ func TestMigrations(t *testing.T) {
 					for i := 0; i < len(oldRTs); i++ {
 						oldRTs[i] = tuplesBeforeUUID{
 							NetworkID: p.NetworkID(ctx),
-							// lint:ignore SA1019
+							//lint:ignore SA1019 backwards compatibility
+							//nolint:staticcheck
 							NamespaceID: namespaces[1].ID,
 							Object:      "object-" + strconv.Itoa(i),
 							Relation:    "pagination-works",

--- a/internal/persistence/sql/migrations/uuidmapping/uuid_mapping_migrator.go
+++ b/internal/persistence/sql/migrations/uuidmapping/uuid_mapping_migrator.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ory/keto/internal/namespace"
 )
 
-// lint:file-ignore SA1019 as we migrate legacy stuff
+//lint:file-ignore SA1019 as we migrate legacy stuff
 
 // We copy the definitions of OldRelationTuple and UUIDMapping here so that the
 // migration will always work on the same definitions.
@@ -123,6 +123,7 @@ func (rt *OldRelationTuple) ToUUID(s string) uuid.UUID {
 }
 
 func namespaceIDtoName(n namespace.Manager, id int32) (string, error) {
+	//nolint:staticcheck
 	ns, err := n.GetNamespaceByConfigID(context.Background(), id)
 	if err != nil {
 		return "", err
@@ -130,7 +131,7 @@ func namespaceIDtoName(n namespace.Manager, id int32) (string, error) {
 	return ns.Name, nil
 }
 
-func (rt *OldRelationTuple) ToNew(n namespace.Manager) (err error, newRT *NewRelationTuple, objectMapping *UUIDMapping, subjectMapping *UUIDMapping) {
+func (rt *OldRelationTuple) ToNew(n namespace.Manager) (newRT *NewRelationTuple, objectMapping *UUIDMapping, subjectMapping *UUIDMapping, err error) {
 	newRT = &NewRelationTuple{
 		ID:        rt.ID,
 		NetworkID: rt.NetworkID,
@@ -209,7 +210,7 @@ var (
 						mappings := make([]*UUIDMapping, len(relationTuples)*2)
 						newTuples := make([]*NewRelationTuple, len(relationTuples))
 						for i := range relationTuples {
-							err, newTuples[i], mappings[i*2], mappings[i*2+1] = relationTuples[i].ToNew(namespaces)
+							newTuples[i], mappings[i*2], mappings[i*2+1], err = relationTuples[i].ToNew(namespaces)
 							if err != nil {
 								return errors.WithStack(err)
 							}
@@ -273,13 +274,14 @@ var (
 							if err != nil {
 								return fmt.Errorf("could not get namespace: %w", err)
 							}
-							ot.NamespaceID = namespace.ID
+							ot.NamespaceID = namespace.ID //nolint:staticcheck
 
 							if rt.SubjectSetNamespace.Valid {
 								subjectSetNamespace, err := namespaces.GetNamespaceByName(ctx, rt.SubjectSetNamespace.String)
 								if err != nil {
 									return fmt.Errorf("could not get subject namespace: %w", err)
 								}
+								//nolint:staticcheck
 								if err = ot.SubjectSetNamespaceID.Scan(subjectSetNamespace.ID); err != nil {
 									return err
 								}

--- a/internal/persistence/sql/persister.go
+++ b/internal/persistence/sql/persister.go
@@ -92,8 +92,8 @@ func (p *Persister) queryWithNetwork(ctx context.Context) *pop.Query {
 	return p.Connection(ctx).Where("nid = ?", p.NetworkID(ctx))
 }
 
-func (p *Persister) transaction(ctx context.Context, f func(ctx context.Context, c *pop.Connection) error) error {
-	return popx.Transaction(ctx, p.conn.WithContext(ctx), f)
+func (p *Persister) Transaction(ctx context.Context, f func(ctx context.Context) error) error {
+	return popx.Transaction(ctx, p.conn.WithContext(ctx), func(ctx context.Context, _ *pop.Connection) error { return f(ctx) })
 }
 
 func (p *Persister) NetworkID(ctx context.Context) uuid.UUID {

--- a/internal/persistence/sql/relationtuples.go
+++ b/internal/persistence/sql/relationtuples.go
@@ -169,7 +169,7 @@ func (p *Persister) DeleteRelationTuples(ctx context.Context, rs ...*relationtup
 	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.DeleteRelationTuples")
 	defer otelx.End(span, &err)
 
-	return p.transaction(ctx, func(ctx context.Context, _ *pop.Connection) error {
+	return p.Transaction(ctx, func(ctx context.Context) error {
 		for _, r := range rs {
 			q := p.queryWithNetwork(ctx).
 				Where("namespace = ?", r.Namespace).
@@ -192,7 +192,7 @@ func (p *Persister) DeleteAllRelationTuples(ctx context.Context, query *relation
 	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.DeleteAllRelationTuples")
 	defer otelx.End(span, &err)
 
-	return p.transaction(ctx, func(ctx context.Context, _ *pop.Connection) error {
+	return p.Transaction(ctx, func(ctx context.Context) error {
 		sqlQuery := p.queryWithNetwork(ctx)
 		err := p.whereQuery(ctx, sqlQuery, query)
 		if err != nil {
@@ -264,7 +264,7 @@ func (p *Persister) WriteRelationTuples(ctx context.Context, rs ...*relationtupl
 	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.WriteRelationTuples")
 	defer otelx.End(span, &err)
 
-	return p.transaction(ctx, func(ctx context.Context, _ *pop.Connection) error {
+	return p.Transaction(ctx, func(ctx context.Context) error {
 		for _, r := range rs {
 			if err := p.InsertRelationTuple(ctx, r); err != nil {
 				return err
@@ -278,7 +278,7 @@ func (p *Persister) TransactRelationTuples(ctx context.Context, ins []*relationt
 	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.TransactRelationTuples")
 	defer otelx.End(span, &err)
 
-	return p.transaction(ctx, func(ctx context.Context, _ *pop.Connection) error {
+	return p.Transaction(ctx, func(ctx context.Context) error {
 		if err := p.WriteRelationTuples(ctx, ins...); err != nil {
 			return err
 		}

--- a/internal/persistence/sql/traverser.go
+++ b/internal/persistence/sql/traverser.go
@@ -31,11 +31,6 @@ type (
 
 		Found bool `db:"found"`
 	}
-
-	rewriteRelationTupleRow struct {
-		RelationTuple
-		Traversal relationtuple.Traversal `db:"traversal"`
-	}
 )
 
 func whereSubject(sub relationtuple.Subject) (sqlFragment string, args []any, err error) {

--- a/internal/relationtuple/handler.go
+++ b/internal/relationtuple/handler.go
@@ -18,6 +18,7 @@ type (
 		x.WriterProvider
 		x.TracingProvider
 		x.NetworkIDProvider
+		x.TransactorProvider
 	}
 	handler struct {
 		d handlerDeps

--- a/internal/relationtuple/read_server.go
+++ b/internal/relationtuple/read_server.go
@@ -73,8 +73,8 @@ func (h *handler) ListRelationTuples(ctx context.Context, req *rts.ListRelationT
 	switch {
 	case req.RelationQuery != nil:
 		q.FromDataProvider(&queryWrapper{req.RelationQuery})
-	case req.Query != nil: // nolint
-		q.FromDataProvider(&deprecatedQueryWrapper{req.Query}) // nolint
+	case req.Query != nil: //nolint:staticcheck //lint:ignore SA1019 backwards compatibility
+		q.FromDataProvider(&deprecatedQueryWrapper{req.Query}) //nolint:staticcheck //lint:ignore SA1019 backwards compatibility
 	default:
 		return nil, herodot.ErrBadRequest.WithError("you must provide a query")
 	}

--- a/internal/relationtuple/read_server_test.go
+++ b/internal/relationtuple/read_server_test.go
@@ -221,17 +221,21 @@ func TestReadHandlers(t *testing.T) {
 		}
 		withDeprecatedQuery := func(req *rts.ListRelationTuplesRequest, query *ketoapi.RelationQuery) {
 			pq := query.ToProto()
-			req.Query = &rts.ListRelationTuplesRequest_Query{ // nolint
+			//nolint:staticcheck
+			req.Query = &rts.ListRelationTuplesRequest_Query{ //lint:ignore SA1019 backwards compatibility
 				Subject: pq.Subject,
 			}
 			if pq.Namespace != nil {
-				req.Query.Namespace = *pq.Namespace // nolint
+				//nolint:staticcheck
+				req.Query.Namespace = *pq.Namespace //lint:ignore SA1019 backwards compatibility
 			}
 			if pq.Object != nil {
-				req.Query.Object = *pq.Object // nolint
+				//nolint:staticcheck
+				req.Query.Object = *pq.Object //lint:ignore SA1019 backwards compatibility
 			}
 			if pq.Relation != nil {
-				req.Query.Relation = *pq.Relation // nolint
+				//nolint:staticcheck
+				req.Query.Relation = *pq.Relation //lint:ignore SA1019 backwards compatibility
 			}
 		}
 		apiTuplesFromProto := func(t *testing.T, pts ...*rts.RelationTuple) []*ketoapi.RelationTuple {

--- a/internal/relationtuple/transact_server.go
+++ b/internal/relationtuple/transact_server.go
@@ -47,12 +47,13 @@ func (h *handler) TransactRelationTuples(ctx context.Context, req *rts.TransactR
 		return nil, err
 	}
 
-	its, err := h.d.Mapper().FromTuple(ctx, append(insertTuples, deleteTuples...)...)
-	if err != nil {
-		return nil, err
-	}
-
-	err = h.d.RelationTupleManager().TransactRelationTuples(ctx, its[:len(insertTuples)], its[len(insertTuples):])
+	err = h.d.Transactor().Transaction(ctx, func(ctx context.Context) error {
+		its, err := h.d.Mapper().FromTuple(ctx, append(insertTuples, deleteTuples...)...)
+		if err != nil {
+			return err
+		}
+		return h.d.RelationTupleManager().TransactRelationTuples(ctx, its[:len(insertTuples)], its[len(insertTuples):])
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -146,14 +147,19 @@ func (h *handler) createRelation(w http.ResponseWriter, r *http.Request, _ httpr
 
 	h.d.Logger().WithFields(rt.ToLoggerFields()).Debug("creating relation tuple")
 
-	it, err := h.d.Mapper().FromTuple(ctx, &rt)
+	err := h.d.Transactor().Transaction(ctx, func(ctx context.Context) error {
+		it, err := h.d.Mapper().FromTuple(ctx, &rt)
+		if err != nil {
+			h.d.Logger().WithError(err).WithFields(rt.ToLoggerFields()).Errorf("could not map relation tuple to UUIDs")
+			return err
+		}
+		if err := h.d.RelationTupleManager().WriteRelationTuples(ctx, it...); err != nil {
+			h.d.Logger().WithError(err).WithFields(rt.ToLoggerFields()).Errorf("got an error while creating the relation tuple")
+			return err
+		}
+		return nil
+	})
 	if err != nil {
-		h.d.Logger().WithError(err).WithFields(rt.ToLoggerFields()).Errorf("could not map relation tuple to UUIDs")
-		h.d.Writer().WriteError(w, r, err)
-		return
-	}
-	if err := h.d.RelationTupleManager().WriteRelationTuples(ctx, it...); err != nil {
-		h.d.Logger().WithError(err).WithFields(rt.ToLoggerFields()).Errorf("got an error while creating the relation tuple")
 		h.d.Writer().WriteError(w, r, err)
 		return
 	}
@@ -283,18 +289,15 @@ func (h *handler) patchRelationTuples(w http.ResponseWriter, r *http.Request, _ 
 	insertTuples := internalTuplesWithAction(deltas, ketoapi.ActionInsert)
 	deleteTuples := internalTuplesWithAction(deltas, ketoapi.ActionDelete)
 
-	its, err := h.d.Mapper().FromTuple(ctx, append(insertTuples, deleteTuples...)...)
+	err := h.d.Transactor().Transaction(ctx, func(ctx context.Context) error {
+		its, err := h.d.Mapper().FromTuple(ctx, append(insertTuples, deleteTuples...)...)
+		if err != nil {
+			h.d.Logger().WithError(err).Errorf("got an error while mapping fields to UUID")
+			return err
+		}
+		return h.d.RelationTupleManager().TransactRelationTuples(ctx, its[:len(insertTuples)], its[len(insertTuples):])
+	})
 	if err != nil {
-		h.d.Logger().WithError(err).Errorf("got an error while mapping fields to UUID")
-		h.d.Writer().WriteError(w, r, err)
-		return
-	}
-	if err := h.d.RelationTupleManager().
-		TransactRelationTuples(
-			ctx,
-			its[:len(insertTuples)],
-			its[len(insertTuples):]); err != nil {
-
 		h.d.Writer().WriteError(w, r, err)
 		return
 	}

--- a/internal/relationtuple/transact_server.go
+++ b/internal/relationtuple/transact_server.go
@@ -74,8 +74,10 @@ func (h *handler) DeleteRelationTuples(ctx context.Context, req *rts.DeleteRelat
 	switch {
 	case req.RelationQuery != nil:
 		q.FromDataProvider(&queryWrapper{req.RelationQuery})
-	case req.Query != nil: // nolint
-		q.FromDataProvider(&deprecatedQueryWrapper{(*rts.ListRelationTuplesRequest_Query)(req.Query)}) // nolint
+		//lint:ignore SA1019 required for compatibility
+	case req.Query != nil: //nolint:staticcheck
+		//lint:ignore SA1019 backwards compatibility
+		q.FromDataProvider(&deprecatedQueryWrapper{(*rts.ListRelationTuplesRequest_Query)(req.Query)}) //nolint:staticcheck
 	default:
 		return nil, errors.WithStack(herodot.ErrBadRequest.WithReason("invalid request"))
 	}
@@ -96,7 +98,8 @@ func (h *handler) DeleteRelationTuples(ctx context.Context, req *rts.DeleteRelat
 // Create Relationship Request Parameters
 //
 // swagger:parameters createRelationship
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 required for OpenAPI
 type createRelationship struct {
 	// in: body
 	Body createRelationshipBody
@@ -105,7 +108,6 @@ type createRelationship struct {
 // Create Relationship Request Body
 //
 // swagger:model createRelationshipBody
-// nolint:deadcode,unused
 type createRelationshipBody struct {
 	ketoapi.RelationQuery
 }

--- a/internal/schema/handler.go
+++ b/internal/schema/handler.go
@@ -54,6 +54,8 @@ func (h *Handler) Check(_ context.Context, request *opl.CheckRequest) (*opl.Chec
 // Check OPL Syntax Request Parameters
 //
 // swagger:parameters checkOplSyntax
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type checkOplSyntax struct {
 	// in: body
 	Body checkOplSyntaxBody
@@ -62,6 +64,8 @@ type checkOplSyntax struct {
 // Ory Permission Language Document
 //
 // swagger:model checkOplSyntaxBody
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type checkOplSyntaxBody string
 
 // swagger:route POST /opl/syntax/check relationship checkOplSyntax

--- a/internal/swagger_types.go
+++ b/internal/swagger_types.go
@@ -6,5 +6,6 @@ package internal
 // Empty responses are sent when, for example, resources are deleted. The HTTP status code for empty responses is typically 204.
 //
 // swagger:response emptyResponse
-// nolint:deadcode,unused
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
 type emptyResponse struct{}

--- a/internal/x/registry.go
+++ b/internal/x/registry.go
@@ -27,3 +27,9 @@ type TracingProvider interface {
 type NetworkIDProvider interface {
 	NetworkID(context.Context) uuid.UUID
 }
+
+type TransactorProvider interface {
+	Transactor() interface {
+		Transaction(ctx context.Context, f func(ctx context.Context) error) error
+	}
+}

--- a/ketoapi/enc_proto.go
+++ b/ketoapi/enc_proto.go
@@ -122,7 +122,8 @@ func (t *Tree[NodeT]) ToProto() *rts.SubjectTree {
 		Children: make([]*rts.SubjectTree, len(t.Children)),
 	}
 	res.Tuple = t.Tuple.ToProto()
-	// nolint - fill deprecated field
+	//lint:ignore SA1019 backwards compatibility
+	//nolint:staticcheck
 	res.Subject = res.Tuple.Subject
 	for i := range t.Children {
 		res.Children[i] = t.Children[i].ToProto()
@@ -137,7 +138,8 @@ func TreeFromProto[T tuple[T]](pt *rts.SubjectTree) *Tree[T] {
 	var tuple T
 	if pt.Tuple == nil {
 		// legacy case: fetch from deprecated fields
-		// nolint
+		//lint:ignore SA1019 backwards compatibility
+		//nolint:staticcheck
 		switch sub := pt.Subject.Ref.(type) {
 		case *rts.Subject_Id:
 			pt.Tuple.Subject = rts.NewSubjectID(sub.Id)

--- a/ketoapi/public_api_definitions.go
+++ b/ketoapi/public_api_definitions.go
@@ -233,7 +233,9 @@ type Tree[T tuple[T]] struct {
 // This can be fixed by using grpc-gateway.
 
 // swagger:model expandedPermissionTree
-type swaggerOnlyExpandTree struct { // nolint
+//
+//lint:ignore U1000 Used to generate Swagger and OpenAPI definitions
+type swaggerOnlyExpandTree struct {
 	// The type of the node.
 	//
 	// required: true

--- a/spec/api.json
+++ b/spec/api.json
@@ -370,6 +370,9 @@
         "required": ["namespace", "object", "relation"],
         "type": "object"
       },
+      "unexpectedError": {
+        "type": "string"
+      },
       "version": {
         "properties": {
           "version": {
@@ -609,15 +612,15 @@
             },
             "description": "Ory Keto is ready to accept connections."
           },
-          "500": {
+          "default": {
             "content": {
-              "application/json": {
+              "text/plain": {
                 "schema": {
-                  "$ref": "#/components/schemas/genericError"
+                  "type": "string"
                 }
               }
             },
-            "description": "genericError"
+            "description": "Unexpected error"
           }
         },
         "summary": "Check HTTP Server Status",
@@ -665,6 +668,16 @@
               }
             },
             "description": "Ory Kratos is not yet ready to accept requests."
+          },
+          "default": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unexpected error"
           }
         },
         "summary": "Check HTTP Server and Database Status",

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -176,7 +176,7 @@
     "/health/alive": {
       "get": {
         "description": "This endpoint returns a 200 status code when the HTTP server is up running.\nThis status does currently not include checks whether the database connection is working.\n\nIf the service supports TLS Edge Termination, this endpoint does not require the\n`X-Forwarded-Proto` header to be set.\n\nBe aware that if you are running multiple nodes of this service, the health status will never\nrefer to the cluster state, only to a single instance.",
-        "produces": ["application/json"],
+        "produces": ["application/json", "text/plain"],
         "tags": ["health"],
         "summary": "Check alive status",
         "operationId": "isInstanceAlive",
@@ -187,10 +187,10 @@
               "$ref": "#/definitions/healthStatus"
             }
           },
-          "500": {
-            "description": "genericError",
+          "default": {
+            "description": "unexpectedError",
             "schema": {
-              "$ref": "#/definitions/genericError"
+              "$ref": "#/definitions/unexpectedError"
             }
           }
         }
@@ -199,7 +199,7 @@
     "/health/ready": {
       "get": {
         "description": "This endpoint returns a 200 status code when the HTTP server is up running and the environment dependencies (e.g.\nthe database) are responsive as well.\n\nIf the service supports TLS Edge Termination, this endpoint does not require the\n`X-Forwarded-Proto` header to be set.\n\nBe aware that if you are running multiple nodes of this service, the health status will never\nrefer to the cluster state, only to a single instance.",
-        "produces": ["application/json"],
+        "produces": ["application/json", "text/plain"],
         "tags": ["health"],
         "summary": "Check readiness status",
         "operationId": "isInstanceReady",
@@ -214,6 +214,12 @@
             "description": "healthNotReadyStatus",
             "schema": {
               "$ref": "#/definitions/healthNotReadyStatus"
+            }
+          },
+          "default": {
+            "description": "unexpectedError",
+            "schema": {
+              "$ref": "#/definitions/unexpectedError"
             }
           }
         }
@@ -1076,6 +1082,9 @@
           "type": "string"
         }
       }
+    },
+    "unexpectedError": {
+      "type": "string"
     },
     "version": {
       "type": "object",


### PR DESCRIPTION
This wraps an SQL transaction around the UUID mapper's and the relation tuple manager's write operations.

Previously, we would insert into the UUID mapping table outside the SQL transaction where we updated/inserted the relation tuples. This is now one transaction.

Beside the obvious benefit of the whole operation being atomic, this improves performance in CockroachDB global tables, where each write operation outside of a transaction takes at least the time to commit the implicit transaction (100++ ms). Inside a transaction, inserts are faster and we have to pay the commit latency only once.

I'm open suggestions on how to better cut across the abstraction layers (handler vs manager/persister) 🤷 .


Before:

<img width="1377" alt="image" src="https://github.com/ory/keto/assets/3969502/4a424e3b-dfb6-4f9e-b4b2-e3bfdaa9b92a">

After:
<img width="1206" alt="image" src="https://github.com/ory/keto/assets/3969502/1adb2769-4cd0-4094-8e8b-3a5c969684e4">

Note: in these traces, the `COMMIT`-equivalent of CRDB is the `sql-conn-exec` before the `sql-tx-commit` span.