### PR TITLE
ci: add merge queue trigger to CVE scan

### DIFF
--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - "master"
+  merge_group:
 
 jobs:
   scanners:


### PR DESCRIPTION
The CVE scan blocks the merge queue, but is not triggered by it.