### PR TITLE
fix: missing block flag on migrate status

### DIFF
--- a/cmd/client/grpc_client.go
+++ b/cmd/client/grpc_client.go
@@ -151,5 +151,5 @@ func RegisterRemoteURLFlags(flags *pflag.FlagSet) {
 	flags.String(FlagAuthority, "", "Set the authority header for the remote gRPC server.")
 	flags.Bool(FlagInsecureNoTransportSecurity, false, "Disables transport security. Do not use this in production.")
 	flags.Bool(FlagInsecureSkipHostVerification, false, "Disables hostname verification. Do not use this in production.")
-	flags.Bool(FlagBlock, false, "Block until all migrations have been applied")
+	flags.Bool(FlagBlock, false, "Block until the connection is up.")
 }

--- a/cmd/migrate/status.go
+++ b/cmd/migrate/status.go
@@ -12,12 +12,12 @@ import (
 	"github.com/ory/x/cmdx"
 	"github.com/spf13/cobra"
 
-	"github.com/ory/keto/cmd/client"
 	"github.com/ory/keto/internal/driver"
 	"github.com/ory/keto/ketoctx"
 )
 
 func newStatusCmd(opts []ketoctx.Option) *cobra.Command {
+	block := false
 	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "Get the current migration status",
@@ -25,11 +25,6 @@ func newStatusCmd(opts []ketoctx.Option) *cobra.Command {
 			"This does not affect namespaces. Use `keto namespace migrate status` for migrating namespaces.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-
-			block, err := cmd.Flags().GetBool(client.FlagBlock)
-			if err != nil {
-				return err
-			}
 
 			reg, err := driver.NewDefaultRegistry(ctx, cmd.Flags(), true, opts)
 			if err != nil {
@@ -54,7 +49,12 @@ func newStatusCmd(opts []ketoctx.Option) *cobra.Command {
 						_, _ = fmt.Fprintf(cmd.OutOrStdout(), " - %s\n", m.Name)
 					}
 				}
-				time.Sleep(time.Second)
+				select {
+				case <-ctx.Done():
+					_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "Context was canceled, exiting...")
+					return cmdx.FailSilently(cmd)
+				case <-time.After(time.Second):
+				}
 				s, err = mb.Status(ctx)
 				if err != nil {
 					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Could not get migration status: %+v\n", err)
@@ -68,6 +68,7 @@ func newStatusCmd(opts []ketoctx.Option) *cobra.Command {
 	}
 
 	cmdx.RegisterFormatFlags(cmd.Flags())
+	cmd.Flags().BoolVar(&block, "block", false, "Block until all migrations have been applied")
 
 	return cmd
 }


### PR DESCRIPTION
A fix for a bug introduced in #1393 where the flag definition was removed from the migrate status command.