### PR TITLE
fix: corrects "quey" typo in internal/x/validate/validate.go to "query"

### DIFF
--- a/internal/x/validate/validate.go
+++ b/internal/x/validate/validate.go
@@ -59,7 +59,7 @@ func QueryParamsContainsOneOf(keys ...string) Validator {
 				return true, ""
 			}
 		}
-		return false, fmt.Sprintf("quey parameters must specify at least one of the following: %s", strings.Join(keys, ", "))
+		return false, fmt.Sprintf("query parameters must specify at least one of the following: %s", strings.Join(keys, ", "))
 	}
 }
 


### PR DESCRIPTION
Corrects a minor typo (`quey` -> `query`) in an error message response returned in `internal/x/validate/validate.go`.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md).
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I am following the
      [contributing code guidelines](../blob/master/CONTRIBUTING.md#contributing-code).
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got the approval (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added or changed [the documentation](https://github.com/ory/docs).

## Further Comments

I can add a test if requested, but the existing tests don't seem to check the actual messages which are returned, so for consistency I've left it out and just changed the one word that's incorrect.