### PR TITLE
feat: add ContextKeyDialFunc

### DIFF
--- a/cmd/client/grpc_client.go
+++ b/cmd/client/grpc_client.go
@@ -39,7 +39,8 @@ const (
 	EnvAuthToken   = "KETO_BEARER_TOKEN" //nolint:gosec // just the key, not the value
 	EnvAuthority   = "KETO_AUTHORITY"
 
-	ContextKeyTimeout contextKeys = "timeout"
+	ContextKeyTimeout  contextKeys = "timeout"
+	ContextKeyDialFunc contextKeys = "dial"
 )
 
 type connectionDetails struct {
@@ -135,6 +136,10 @@ func Conn(ctx context.Context, remote string, details connectionDetails) (*grpc.
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, d)
 		defer cancel()
+	}
+
+	if dial, ok := ctx.Value(ContextKeyDialFunc).(func(context.Context, string) (*grpc.ClientConn, error)); ok {
+		return dial(ctx, remote)
 	}
 
 	return grpc.DialContext(


### PR DESCRIPTION
This allows hooking the dial function for gRPC, for use with OAuth authentication in ory/cli.