### PR TITLE
fix: unused order

### DIFF
--- a/internal/persistence/sql/relationtuples.go
+++ b/internal/persistence/sql/relationtuples.go
@@ -214,7 +214,7 @@ func (p *Persister) GetRelationTuples(ctx context.Context, query *relationtuple.
 	}
 
 	sqlQuery := p.queryWithNetwork(ctx).
-		Order("shard_id, nid").
+		Order("shard_id").
 		Where("shard_id > ?", pagination.LastID).
 		Limit(pagination.PerPage + 1)
 

--- a/internal/persistence/sql/traverser.go
+++ b/internal/persistence/sql/traverser.go
@@ -85,7 +85,7 @@ WHERE current.nid = ? AND
       current.object = ? AND
       current.relation = ? AND
       current.subject_id IS NULL
-ORDER BY current.nid, current.shard_id
+ORDER BY current.shard_id
 LIMIT ?
 `, targetSubjectSQL),
 			append(targetSubjectArgs, t.p.NetworkID(ctx), shardID, start.Namespace, start.Object, start.Relation, limit)...,


### PR DESCRIPTION
We filter for `nid = ?` so there is no point in ordering by nid.

Column `shard_id` is the prefix (`CONSTRAINT keto_relation_tuples_uuid_pkey PRIMARY KEY (shard_id ASC, nid ASC)`) so it should not impact the query planner.