### PR TITLE
feat: write listen files with actual address

### DIFF
--- a/embedx/config.schema.json
+++ b/embedx/config.schema.json
@@ -211,6 +211,13 @@
               "title": "Host",
               "description": "The network interface to listen on."
             },
+            "write_listen_file": {
+              "type": "string",
+              "title": "Read Listen File",
+              "description": "The path to a file that will be created when the read API is ready to accept connections. The content of the file is the host:port of the read API. Use this to get the actual port when using port 0. The service might not yet be ready to accept connections when the file is created.",
+              "format": "uri",
+              "examples": ["file:///tmp/keto-read-api"]
+            },
             "cors": {
               "$ref": "#/definitions/cors"
             },
@@ -238,6 +245,13 @@
               "examples": ["localhost", "127.0.0.1"],
               "title": "Host",
               "description": "The network interface to listen on."
+            },
+            "write_listen_file": {
+              "type": "string",
+              "title": "Write Listen File",
+              "description": "The path to a file that will be created when the write API is ready to accept connections. The content of the file is the host:port of the write API. Use this to get the actual port when using port 0. The service might not yet be ready to accept connections when the file is created.",
+              "format": "uri",
+              "examples": ["file:///tmp/keto-write-api"]
             },
             "cors": {
               "$ref": "#/definitions/cors"
@@ -267,6 +281,13 @@
               "title": "Host",
               "description": "The network interface to listen on."
             },
+            "write_listen_file": {
+              "type": "string",
+              "title": "Metrics Listen File",
+              "description": "The path to a file that will be created when the metrics API is ready to accept connections. The content of the file is the host:port of the metrics API. Use this to get the actual port when using port 0. The service might not yet be ready to accept connections when the file is created.",
+              "format": "uri",
+              "examples": ["file:///tmp/keto-metrics-api"]
+            },
             "cors": {
               "$ref": "#/definitions/cors"
             },
@@ -294,6 +315,13 @@
               "examples": ["localhost", "127.0.0.1"],
               "title": "Host",
               "description": "The network interface to listen on."
+            },
+            "write_listen_file": {
+              "type": "string",
+              "title": "OPL Listen File",
+              "description": "The path to a file that will be created when the OPL API is ready to accept connections. The content of the file is the host:port of the OPL API. Use this to get the actual port when using port 0. The service might not yet be ready to accept connections when the file is created.",
+              "format": "uri",
+              "examples": ["file:///tmp/keto-opl-api"]
             },
             "cors": {
               "$ref": "#/definitions/cors"

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,8 @@ require (
 	github.com/ory/herodot v0.10.3-0.20230626083119-d7e5192f0d88
 	github.com/ory/jsonschema/v3 v3.0.8
 	github.com/ory/keto/proto v0.13.0-alpha.0
-	github.com/ory/x v0.0.647
+	github.com/ory/x v0.0.662
 	github.com/pelletier/go-toml v1.9.5
-	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.55.0
@@ -34,7 +33,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.9.1-0.20240613200951-b074924938f8
 	github.com/tidwall/gjson v1.17.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/urfave/negroni v1.0.0
@@ -146,11 +145,12 @@ require (
 	github.com/nyaruka/phonenumbers v1.1.8 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
-	github.com/opencontainers/runc v1.1.13 // indirect
+	github.com/opencontainers/runc v1.1.14 // indirect
 	github.com/openzipkin/zipkin-go v0.4.2 // indirect
 	github.com/ory/dockertest/v3 v3.11.0 // indirect
 	github.com/ory/go-acc v0.2.9-0.20230103102148-6b1c9a70dbbe // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 // indirect
 	github.com/pkg/profile v1.7.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/opencontainers/runc v1.1.13 h1:98S2srgG9vw0zWcDpFMn5TRrh8kLxa/5OFUstuUhmRs=
-github.com/opencontainers/runc v1.1.13/go.mod h1:R016aXacfp/gwQBYw2FDGa9m+n6atbLWrYY8hNMT/sA=
+github.com/opencontainers/runc v1.1.14 h1:rgSuzbmgz5DUJjeSnw337TxDbRuqjs6iqQck/2weR6w=
+github.com/opencontainers/runc v1.1.14/go.mod h1:E4C2z+7BxR7GHXp0hAY53mek+x49X1LjPNeMTfRGvOA=
 github.com/openzipkin/zipkin-go v0.4.2 h1:zjqfqHjUpPmB3c1GlCvvgsM1G4LkvqQbBDueDOCg/jA=
 github.com/openzipkin/zipkin-go v0.4.2/go.mod h1:ZeVkFjuuBiSy13y8vpSDCjMi9GoI3hPpCJSBx/EYFhY=
 github.com/ory/analytics-go/v5 v5.0.1 h1:LX8T5B9FN8KZXOtxgN+R3I4THRRVB6+28IKgKBpXmAM=
@@ -487,8 +487,8 @@ github.com/ory/herodot v0.10.3-0.20230626083119-d7e5192f0d88 h1:J0CIFKdpUeqKbVMw
 github.com/ory/herodot v0.10.3-0.20230626083119-d7e5192f0d88/go.mod h1:MMNmY6MG1uB6fnXYFaHoqdV23DTWctlPsmRCeq/2+wc=
 github.com/ory/jsonschema/v3 v3.0.8 h1:Ssdb3eJ4lDZ/+XnGkvQS/te0p+EkolqwTsDOCxr/FmU=
 github.com/ory/jsonschema/v3 v3.0.8/go.mod h1:ZPzqjDkwd3QTnb2Z6PAS+OTvBE2x5i6m25wCGx54W/0=
-github.com/ory/x v0.0.647 h1:DVKgA3ykMB9qXuMdSl5C8SFWr3yw7Xe8jpSm0+iqGeU=
-github.com/ory/x v0.0.647/go.mod h1:M+0EAXo7DT7Z2/Yrzvh4mgxOoV1fGI1jOKyAJ72d4Qs=
+github.com/ory/x v0.0.662 h1:Qah5/f63Kr33Wcqm1S79adcYHaoWeiCDMQiDLuUXBqU=
+github.com/ory/x v0.0.662/go.mod h1:tS0FyZXpVeKd1lCcFgV/Rb1GlccI/Xq8DraFS+lmIt8=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
@@ -587,8 +587,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.9.1-0.20240613200951-b074924938f8 h1:lMSOB3NNaQcNDK9eCjQb0LFfpXW03lzF2SN6vUziALo=
+github.com/stretchr/testify v1.9.1-0.20240613200951-b074924938f8/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/internal/driver/config/provider.go
+++ b/internal/driver/config/provider.go
@@ -43,14 +43,18 @@ const (
 	KeyBatchCheckMaxBatchSize         = "limit.max_batch_check_size"
 	KeyBatchCheckParallelizationLimit = "limit.batch_check_max_parallelization"
 
-	KeyReadAPIHost      = "serve." + string(EndpointRead) + ".host"
-	KeyReadAPIPort      = "serve." + string(EndpointRead) + ".port"
-	KeyWriteAPIHost     = "serve." + string(EndpointWrite) + ".host"
-	KeyWriteAPIPort     = "serve." + string(EndpointWrite) + ".port"
-	KeyOPLSyntaxAPIHost = "serve." + string(EndpointOPLSyntax) + ".host"
-	KeyOPLSyntaxAPIPort = "serve." + string(EndpointOPLSyntax) + ".port"
-	KeyMetricsHost      = "serve." + string(EndpointMetrics) + ".host"
-	KeyMetricsPort      = "serve." + string(EndpointMetrics) + ".port"
+	KeyReadAPIHost         = "serve." + string(EndpointRead) + ".host"
+	KeyReadAPIPort         = "serve." + string(EndpointRead) + ".port"
+	KeyReadAPIListenFile   = "serve." + string(EndpointRead) + ".write_listen_file"
+	KeyWriteAPIHost        = "serve." + string(EndpointWrite) + ".host"
+	KeyWriteAPIPort        = "serve." + string(EndpointWrite) + ".port"
+	KeyWriteAPIListenFile  = "serve." + string(EndpointWrite) + ".write_listen_file"
+	KeyOPLSyntaxAPIHost    = "serve." + string(EndpointOPLSyntax) + ".host"
+	KeyOPLSyntaxAPIPort    = "serve." + string(EndpointOPLSyntax) + ".port"
+	KeyOPLSyntaxListenFile = "serve." + string(EndpointOPLSyntax) + ".write_listen_file"
+	KeyMetricsHost         = "serve." + string(EndpointMetrics) + ".host"
+	KeyMetricsPort         = "serve." + string(EndpointMetrics) + ".port"
+	KeyMetricsListenFile   = "serve." + string(EndpointMetrics) + ".write_listen_file"
 
 	KeyNamespaces                       = "namespaces"
 	KeyNamespacesExperimentalStrictMode = KeyNamespaces + ".experimental_strict_mode"
@@ -167,18 +171,18 @@ func (k *Config) Set(key string, v any) error {
 	return nil
 }
 
-func (k *Config) addressFor(endpoint EndpointType) string {
+func (k *Config) addressFor(endpoint EndpointType) (string, string) {
 	return fmt.Sprintf(
 		"%s:%d",
 		k.p.StringF("serve."+string(endpoint)+".host", ""),
 		k.p.IntF("serve."+string(endpoint)+".port", 0),
-	)
+	), k.p.StringF("serve."+string(endpoint)+".write_listen_file", "")
 }
 
-func (k *Config) ReadAPIListenOn() string      { return k.addressFor(EndpointRead) }
-func (k *Config) WriteAPIListenOn() string     { return k.addressFor(EndpointWrite) }
-func (k *Config) MetricsListenOn() string      { return k.addressFor(EndpointMetrics) }
-func (k *Config) OPLSyntaxAPIListenOn() string { return k.addressFor(EndpointOPLSyntax) }
+func (k *Config) ReadAPIListenOn() (string, string)      { return k.addressFor(EndpointRead) }
+func (k *Config) WriteAPIListenOn() (string, string)     { return k.addressFor(EndpointWrite) }
+func (k *Config) MetricsListenOn() (string, string)      { return k.addressFor(EndpointMetrics) }
+func (k *Config) OPLSyntaxAPIListenOn() (string, string) { return k.addressFor(EndpointOPLSyntax) }
 
 func (k *Config) MaxReadDepth() int {
 	return k.p.Int(KeyLimitMaxReadDepth)

--- a/internal/driver/config/provider_test.go
+++ b/internal/driver/config/provider_test.go
@@ -283,5 +283,7 @@ func TestProvider_DefaultReadAPIListenOn(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	assert.Equal(t, ":4466", config.ReadAPIListenOn())
+	addr, listenFile := config.ReadAPIListenOn()
+	assert.Equal(t, ":4466", addr)
+	assert.Zero(t, listenFile)
 }

--- a/internal/driver/testhelpers.go
+++ b/internal/driver/testhelpers.go
@@ -1,0 +1,63 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/keto/internal/driver/config"
+)
+
+type GetAddr = func(testing.TB, string) (host string, port string, fullAddr string)
+
+func UseDynamicPorts(ctx context.Context, t testing.TB, r Registry) GetAddr {
+	t.Helper()
+
+	listenDir := t.TempDir()
+	readListenFile := fmt.Sprintf("%s/read.addr", listenDir)
+	writeListenFile := fmt.Sprintf("%s/write.addr", listenDir)
+	metricsListenFile := fmt.Sprintf("%s/metrics.addr", listenDir)
+	oplListenFile := fmt.Sprintf("%s/opl.addr", listenDir)
+
+	require.NoError(t, r.Config(ctx).Set(config.KeyReadAPIPort, 0))
+	require.NoError(t, r.Config(ctx).Set(config.KeyReadAPIListenFile, "file://"+readListenFile))
+	require.NoError(t, r.Config(ctx).Set(config.KeyWriteAPIPort, 0))
+	require.NoError(t, r.Config(ctx).Set(config.KeyWriteAPIListenFile, "file://"+writeListenFile))
+	require.NoError(t, r.Config(ctx).Set(config.KeyMetricsPort, 0))
+	require.NoError(t, r.Config(ctx).Set(config.KeyMetricsListenFile, "file://"+metricsListenFile))
+	require.NoError(t, r.Config(ctx).Set(config.KeyOPLSyntaxAPIPort, 0))
+	require.NoError(t, r.Config(ctx).Set(config.KeyOPLSyntaxListenFile, "file://"+oplListenFile))
+
+	return func(t testing.TB, endpoint string) (string, string, string) {
+		fp := ""
+		switch endpoint {
+		case "read":
+			fp = readListenFile
+		case "write":
+			fp = writeListenFile
+		case "metrics":
+			fp = metricsListenFile
+		case "opl":
+			fp = oplListenFile
+		default:
+			t.Fatalf("unknown endpoint: %q", endpoint)
+		}
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			_, err := os.Stat(fp)
+			require.NoError(t, err)
+		}, 2*time.Second, 10*time.Millisecond)
+
+		addr, err := os.ReadFile(fp)
+		require.NoError(t, err)
+		host, port, err := net.SplitHostPort(string(addr))
+		require.NoError(t, err)
+		return host, port, string(addr)
+	}
+}

--- a/internal/e2e/full_suit_test.go
+++ b/internal/e2e/full_suit_test.go
@@ -57,24 +57,29 @@ func Test(t *testing.T) {
 		t.Run(fmt.Sprintf("dsn=%s", dsn.Name), func(t *testing.T) {
 			t.Parallel()
 
-			ctx, reg, namespaceTestMgr := newInitializedReg(t, dsn, nil)
+			ctx, reg, namespaceTestMgr, getAddr := newInitializedReg(t, dsn, nil)
 
 			closeServer := startServer(ctx, t, reg)
 			t.Cleanup(closeServer)
+
+			_, _, readAddr := getAddr(t, "read")
+			_, _, writeAddr := getAddr(t, "write")
+			_, _, oplAddr := getAddr(t, "opl")
+			_, _, metricsAddr := getAddr(t, "metrics")
 
 			// The test cases start here
 			// We execute every test with all clients available
 			for _, cl := range []client{
 				&grpcClient{
-					readRemote:      reg.Config(ctx).ReadAPIListenOn(),
-					writeRemote:     reg.Config(ctx).WriteAPIListenOn(),
-					oplSyntaxRemote: reg.Config(ctx).OPLSyntaxAPIListenOn(),
+					readRemote:      readAddr,
+					writeRemote:     writeAddr,
+					oplSyntaxRemote: oplAddr,
 					ctx:             ctx,
 				},
 				&restClient{
-					readURL:      "http://" + reg.Config(ctx).ReadAPIListenOn(),
-					writeURL:     "http://" + reg.Config(ctx).WriteAPIListenOn(),
-					oplSyntaxURL: "http://" + reg.Config(ctx).OPLSyntaxAPIListenOn(),
+					readURL:      "http://" + readAddr,
+					writeURL:     "http://" + writeAddr,
+					oplSyntaxURL: "http://" + oplAddr,
 				},
 				&cliClient{c: &cmdx.CommandExecuter{
 					New: func() *cobra.Command {
@@ -82,16 +87,16 @@ func Test(t *testing.T) {
 					},
 					Ctx: ctx,
 					PersistentArgs: []string{
-						"--" + cliclient.FlagReadRemote, reg.Config(ctx).ReadAPIListenOn(),
-						"--" + cliclient.FlagWriteRemote, reg.Config(ctx).WriteAPIListenOn(),
+						"--" + cliclient.FlagReadRemote, readAddr,
+						"--" + cliclient.FlagWriteRemote, writeAddr,
 						"--insecure-disable-transport-security=true",
 						"--" + cmdx.FlagFormat, string(cmdx.FormatJSON),
 					},
 				}},
 				&sdkClient{
-					readRemote:   reg.Config(ctx).ReadAPIListenOn(),
-					writeRemote:  reg.Config(ctx).WriteAPIListenOn(),
-					syntaxRemote: reg.Config(ctx).OPLSyntaxAPIListenOn(),
+					readRemote:   readAddr,
+					writeRemote:  writeAddr,
+					syntaxRemote: oplAddr,
 				},
 			} {
 				cl := cl
@@ -105,14 +110,14 @@ func Test(t *testing.T) {
 			t.Run("case=metrics are served", func(t *testing.T) {
 				t.Parallel()
 				(&grpcClient{
-					readRemote:  reg.Config(ctx).ReadAPIListenOn(),
-					writeRemote: reg.Config(ctx).WriteAPIListenOn(),
+					readRemote:  readAddr,
+					writeRemote: writeAddr,
 					ctx:         ctx,
 				}).waitUntilLive(t)
 
 				t.Run("case=on "+prometheus.MetricsPrometheusPath, func(t *testing.T) {
 					t.Parallel()
-					resp, err := http.Get(fmt.Sprintf("http://%s%s", reg.Config(ctx).MetricsListenOn(), prometheus.MetricsPrometheusPath))
+					resp, err := http.Get(fmt.Sprintf("http://%s%s", metricsAddr, prometheus.MetricsPrometheusPath))
 					require.NoError(t, err)
 					require.Equal(t, resp.StatusCode, http.StatusOK)
 					body, err := io.ReadAll(resp.Body)
@@ -122,7 +127,7 @@ func Test(t *testing.T) {
 
 				t.Run("case=not on /", func(t *testing.T) {
 					t.Parallel()
-					resp, err := http.Get(fmt.Sprintf("http://%s", reg.Config(ctx).MetricsListenOn()))
+					resp, err := http.Get(fmt.Sprintf("http://%s", metricsAddr))
 					require.NoError(t, err)
 					require.Equal(t, resp.StatusCode, http.StatusNotFound)
 				})
@@ -134,7 +139,7 @@ func Test(t *testing.T) {
 func TestServeConfig(t *testing.T) {
 	t.Parallel()
 
-	ctx, reg, _ := newInitializedReg(t, dbx.GetSqlite(t, dbx.SQLiteMemory), map[string]interface{}{
+	ctx, reg, _, getAddr := newInitializedReg(t, dbx.GetSqlite(t, dbx.SQLiteMemory), map[string]interface{}{
 		"serve.read.cors.enabled":         true,
 		"serve.read.cors.debug":           true,
 		"serve.read.cors.allowed_methods": []string{http.MethodGet},
@@ -144,12 +149,14 @@ func TestServeConfig(t *testing.T) {
 	closeServer := startServer(ctx, t, reg)
 	t.Cleanup(closeServer)
 
-	for !healthReady(t, "http://"+reg.Config(ctx).ReadAPIListenOn()) {
+	_, _, readAddr := getAddr(t, "read")
+
+	for !healthReady(t, "http://"+readAddr) {
 		t.Log("Waiting for health check to be ready")
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	req, err := http.NewRequest(http.MethodOptions, "http://"+reg.Config(ctx).ReadAPIListenOn()+relationtuple.ReadRouteBase, nil)
+	req, err := http.NewRequest(http.MethodOptions, "http://"+readAddr+relationtuple.ReadRouteBase, nil)
 	require.NoError(t, err)
 	req.Header.Set("Origin", "https://ory.sh")
 	resp, err := http.DefaultClient.Do(req)

--- a/internal/e2e/grpc_client_test.go
+++ b/internal/e2e/grpc_client_test.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"google.golang.org/grpc/codes"
 	"time"
 
 	"github.com/ory/keto/ketoapi"
@@ -220,28 +221,26 @@ func (g *grpcClient) expand(t require.TestingT, r *ketoapi.SubjectSet, depth int
 }
 
 func (g *grpcClient) waitUntilLive(t require.TestingT) {
-	c := grpcHealthV1.NewHealthClient(g.readConn(t))
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		c := grpcHealthV1.NewHealthClient(g.readConn(t))
 
-	ctx, cancel := context.WithCancel(g.ctx)
-	defer cancel()
+		ctx, cancel := context.WithCancel(g.ctx)
+		defer cancel()
 
-	cl, err := c.Watch(ctx, &grpcHealthV1.HealthCheckRequest{})
-	require.NoError(t, err)
-	require.NoError(t, cl.CloseSend())
-
-	for {
-		select {
-		case <-g.ctx.Done():
-			return
-		default:
-		}
-		resp, err := cl.Recv()
+		cl, err := c.Watch(ctx, &grpcHealthV1.HealthCheckRequest{})
 		require.NoError(t, err)
+		require.NoError(t, cl.CloseSend())
 
-		if resp.Status == grpcHealthV1.HealthCheckResponse_SERVING {
-			return
+		for {
+			resp, err := cl.Recv()
+			if status.Code(err) == codes.Unavailable {
+				continue
+			}
+			if resp.Status == grpcHealthV1.HealthCheckResponse_SERVING {
+				return
+			}
 		}
-	}
+	}, 2*time.Second, 100*time.Millisecond)
 }
 
 func (g *grpcClient) deleteTuple(t require.TestingT, r *ketoapi.RelationTuple) {

--- a/internal/e2e/grpc_client_test.go
+++ b/internal/e2e/grpc_client_test.go
@@ -6,8 +6,9 @@ package e2e
 import (
 	"context"
 	"encoding/json"
-	"google.golang.org/grpc/codes"
 	"time"
+
+	"google.golang.org/grpc/codes"
 
 	"github.com/ory/keto/ketoapi"
 	opl "github.com/ory/keto/proto/ory/keto/opl/v1alpha1"


### PR DESCRIPTION
It is now possible to set a `write_listen_file` URL in the config for each port. The server will write the actual listen address to that file, so it is now possible to easily use port `0`.