### PR TITLE
feat: deduplicate UUID mappings before database insert

### DIFF
--- a/internal/e2e/transaction_cases_test.go
+++ b/internal/e2e/transaction_cases_test.go
@@ -62,6 +62,25 @@ func runTransactionCases(c transactClient, m *namespaceTestManager) func(*testin
 			assert.Len(t, resp.RelationTuples, 0)
 		})
 
+		t.Run("case=duplicate string representations", func(t *testing.T) {
+			n := &namespace.Namespace{Name: t.Name()}
+			m.add(t, n)
+			c.transactTuples(t, []*ketoapi.RelationTuple{
+				{
+					Namespace: n.Name,
+					Object:    "o",
+					Relation:  "rel",
+					SubjectID: pointerx.Ptr("sid"),
+				},
+				{
+					Namespace: n.Name,
+					Object:    "o",
+					Relation:  "rel",
+					SubjectID: pointerx.Ptr("sid"),
+				},
+			}, nil)
+		})
+
 		t.Run("case=large inserts and deletes", func(t *testing.T) {
 			if !testing.Short() {
 				t.Skip("This test is fairly expensive, especially the deletion.")

--- a/internal/persistence/sql/relationtuples.go
+++ b/internal/persistence/sql/relationtuples.go
@@ -175,13 +175,13 @@ func buildDelete(nid uuid.UUID, rs []*relationtuple.RelationTuple) (query string
 }
 
 func (p *Persister) DeleteRelationTuples(ctx context.Context, rs ...*relationtuple.RelationTuple) (err error) {
-	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.DeleteRelationTuples",
-		trace.WithAttributes(attribute.Int("count", len(rs))))
-	defer otelx.End(span, &err)
-
 	if len(rs) == 0 {
 		return nil
 	}
+
+	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.DeleteRelationTuples",
+		trace.WithAttributes(attribute.Int("count", len(rs))))
+	defer otelx.End(span, &err)
 
 	return p.Transaction(ctx, func(ctx context.Context) error {
 		for chunk := range slices.Chunk(rs, chunkSizeDeleteTuple) {
@@ -310,13 +310,13 @@ func buildInsert(commitTime time.Time, nid uuid.UUID, rs []*relationtuple.Relati
 }
 
 func (p *Persister) WriteRelationTuples(ctx context.Context, rs ...*relationtuple.RelationTuple) (err error) {
-	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.WriteRelationTuples",
-		trace.WithAttributes(attribute.Int("count", len(rs))))
-	defer otelx.End(span, &err)
-
 	if len(rs) == 0 {
 		return nil
 	}
+
+	ctx, span := p.d.Tracer(ctx).Tracer().Start(ctx, "persistence.sql.WriteRelationTuples",
+		trace.WithAttributes(attribute.Int("count", len(rs))))
+	defer otelx.End(span, &err)
 
 	commitTime := time.Now()
 


### PR DESCRIPTION
Quite difficult to tell how much this actually helps, but it certainly can't hurt.

I've also moved around some tracing code to reduce empty spans.