### PR TITLE
allow additional ranges of ips

### DIFF
--- a/oryx/httpx/ssrf.go
+++ b/oryx/httpx/ssrf.go
@@ -89,10 +89,12 @@ func init() {
 		ssrf.WithNetworks("tcp4", "tcp6"),
 		ssrf.WithAllowedV4Prefixes(
 			netip.MustParsePrefix("10.0.0.0/8"),     // Private-Use (RFC 1918)
+			netip.MustParsePrefix("100.64.0.0/10"), // Shared Address Space (RFC 6598)
 			netip.MustParsePrefix("127.0.0.0/8"),    // Loopback (RFC 1122, Section 3.2.1.3))
 			netip.MustParsePrefix("169.254.0.0/16"), // Link Local (RFC 3927)
 			netip.MustParsePrefix("172.16.0.0/12"),  // Private-Use (RFC 1918)
 			netip.MustParsePrefix("192.168.0.0/16"), // Private-Use (RFC 1918)
+			netip.MustParsePrefix("198.18.0.0/15"), // Benchmarking (RFC 2544)
 		),
 		ssrf.WithAllowedV6Prefixes(
 			netip.MustParsePrefix("::1/128"),  // Loopback (RFC 4193)
@@ -109,10 +111,12 @@ func init() {
 		ssrf.WithNetworks("tcp4"),
 		ssrf.WithAllowedV4Prefixes(
 			netip.MustParsePrefix("10.0.0.0/8"),     // Private-Use (RFC 1918)
+			netip.MustParsePrefix("100.64.0.0/10"), // Shared Address Space (RFC 6598)
 			netip.MustParsePrefix("127.0.0.0/8"),    // Loopback (RFC 1122, Section 3.2.1.3))
 			netip.MustParsePrefix("169.254.0.0/16"), // Link Local (RFC 3927)
 			netip.MustParsePrefix("172.16.0.0/12"),  // Private-Use (RFC 1918)
 			netip.MustParsePrefix("192.168.0.0/16"), // Private-Use (RFC 1918)
+			netip.MustParsePrefix("198.18.0.0/15"), // Benchmarking (RFC 2544)
 		),
 		ssrf.WithAllowedV6Prefixes(
 			netip.MustParsePrefix("::1/128"),  // Loopback (RFC 4193)


### PR DESCRIPTION
We have the same situation that is described in this PR
https://github.com/ory/x/pull/806

A customer is using range 198.18.0.0/16 for their K8s services, and kratos is therefore unable to access other services (perminator in our case).

The situation comes from SSRF component used by kratos, that limits access to these IP ranges:
https://github.com/daenney/ssrf/blob/main/ssrf_gen.go#L49